### PR TITLE
Add 'make disco' command to enable discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,6 @@ up-zotonic:
 
 update:
 	@docker-compose pull
+
+disco:
+	@docker run -d -p 8301:8301/udp -p 8301:8301 -e DOCKER_USER=$(USER) -e DOCKER_SERVICE=ginger -e DOCKER_PORT=80 driebit/disco:latest agent -rejoin -retry-join=10.0.0.10 -dc=office


### PR DESCRIPTION
Enables foo.ginger.dev in the Driebit office lan. Since it is not dependent on the ginger containers running (and the ginger container isn't dependent on it), I figured it would be best to make it a separate command, to be run on-demand, which starts a container in daemon mode.