### PR TITLE
Exclude googlemaps javascript loading when mod_geo is not configured

### DIFF
--- a/modules/mod_ginger_foundation/templates/_script.tpl
+++ b/modules/mod_ginger_foundation/templates/_script.tpl
@@ -1,5 +1,3 @@
-<script src="//maps.googleapis.com/maps/api/js?libraries=places&amp;sensor=false&amp;language=nl&amp;v=3"></script>
-
 {% lib
     "bootstrap/js/bootstrap.min.js"
     "js/qlobber.js"
@@ -18,9 +16,6 @@
     "js/parallax.js"
     "js/anchor.js"
     "js/expand.js"
-    "js/vendors/infobox_packed.js"
-    "js/vendors/markerclusterer.js"
-    "js/map.js"
     "js/vendors/flowplayer-3.2.12.min.js"
     "js/vendors/slick.min.js"
     "js/vendors/purl.js"
@@ -32,3 +27,13 @@
     "js/search/components/types.js"
     "js/mail-decode.js"
 %}
+
+{% if m.modules.active.mod_geo %}
+    <script src="//maps.googleapis.com/maps/api/js?libraries=places&amp;sensor=false&amp;language=nl&amp;v=3"></script>
+    {% lib
+        "js/vendors/infobox_packed.js"
+        "js/vendors/markerclusterer.js"
+        "js/map.js"
+    %}
+{% endif %}
+    


### PR DESCRIPTION
Saves page loading time when google maps is not needed on a site and prevents javascript errors when no api key is configured