### PR TITLE
Toggle definitions in body text

### DIFF
--- a/modules/mod_ginger_base/lib/js/base.js
+++ b/modules/mod_ginger_base/lib/js/base.js
@@ -59,6 +59,8 @@
             $(document).on('click', $.proxy(me._documentClick, me));
             $(document).on('keyup', $.proxy(me._documentKeyUp, me));
 
+            $('.toggledefinition').addClass('do_toggledefinition');
+
         },
 
         _documentClick: function(event) {

--- a/modules/mod_ginger_base/lib/js/toggle-definition.js
+++ b/modules/mod_ginger_base/lib/js/toggle-definition.js
@@ -1,0 +1,37 @@
+(function($) {
+    'use strict';
+
+    $.widget("ui.toggledefinition", {
+
+        _init: function() {
+
+            var me = this,
+                element = $(me.element);
+
+            me.element = element;
+
+            element.on('click', function() {
+
+                var content = me.element.attr('title');
+
+                me.element.toggleClass('show');
+
+                if (me.element.hasClass('show')) {
+
+                    var abbr = $('<span class="toggle-content">' + content + '</span>');
+                    me.abbr = abbr;
+                    me.element.after(abbr);
+
+                } else {
+                    me.abbr.remove();
+                }
+
+                return false;
+
+            });
+
+        }
+
+    });
+
+})(jQuery);

--- a/modules/mod_ginger_foundation/lib/css/src/blocks/_toggle-definition.scss
+++ b/modules/mod_ginger_foundation/lib/css/src/blocks/_toggle-definition.scss
@@ -1,0 +1,35 @@
+.do_toggle,
+.toggledefinition {
+    @include size(padding, 0, 24, 0, 0);
+    position: relative;
+
+    &:after {
+        @extend .has-icon;
+        @extend .icon--arrow-down:before;
+        position: absolute;
+        right: 7px;
+        top: 6px;
+        transition: transform 0.3s;
+        font-size: 8px;
+    }
+
+    &.show:after {
+        transform: rotate(180deg);
+        top: 5px;
+    }
+
+}
+
+.toggle-content {
+    display: block;
+    padding: 15px;
+    font-family: $secondaryFontFamily;
+    font-size: 15px;
+}
+
+
+@include mq(min-width, $smallBreakpoint) {
+    .toggle-content {
+        padding: 30px;
+    }
+}

--- a/modules/mod_ginger_foundation/templates/_script.tpl
+++ b/modules/mod_ginger_foundation/templates/_script.tpl
@@ -26,6 +26,7 @@
     "js/search/components/pager.js"
     "js/search/components/types.js"
     "js/mail-decode.js"
+    "js/toggle-definition.js"
 %}
 
 {% if m.modules.active.mod_geo %}


### PR DESCRIPTION
I've added the javascript and the styles for this. One thing remains and that is the configuration of the tinymce. I'm not sure where to put this configuration. @ddeboer what do you think? Make a default config in ginger base or in ginger foundation? Now the admin_tinymce overrides is in the ginger edit module. Not sure what will happen if we also put a file in base or foundation, @fredpook you have some experience with this?
