### PR TITLE
[rdf] Include JSON-LD in pages

### DIFF
--- a/modules/mod_ginger_rdf/models/m_rdf.erl
+++ b/modules/mod_ginger_rdf/models/m_rdf.erl
@@ -20,6 +20,8 @@
 
 m_find_value(#rdf_resource{} = Rdf, #m{value = undefined} = M, _Context) ->
     M#m{value = Rdf};
+m_find_value(Id, #m{value = undefined}, Context) when is_integer(Id) ->
+    mochijson2:encode(ginger_json_ld:serialize(to_triples(Id, Context)));
 m_find_value(id, #m{value = #rdf_resource{id = Id}}, _Context) ->
     Id;
 m_find_value(uri, #m{value = #rdf_resource{id = Id}}, _Context) ->

--- a/modules/mod_ginger_rdf/templates/_html_head.tpl
+++ b/modules/mod_ginger_rdf/templates/_html_head.tpl
@@ -1,0 +1,1 @@
+    <link rel="alternate" type="application/ld+json" href="{% url rsc_json_ld id=id %}">

--- a/modules/mod_ginger_rdf/templates/_script.tpl
+++ b/modules/mod_ginger_rdf/templates/_script.tpl
@@ -1,0 +1,1 @@
+{% include "rdf/resource.tpl" %}

--- a/modules/mod_ginger_rdf/templates/rdf/resource.tpl
+++ b/modules/mod_ginger_rdf/templates/rdf/resource.tpl
@@ -1,0 +1,1 @@
+<script type="application/ld+json">{{ m.rdf[id] }}</script>


### PR DESCRIPTION
Fix #179.

* Add an alternate link.
* Because search engines don't follow those links, also include the JSON-LD in the page.
* Tested against Google's structured data testing tool (https://search.google.com/structured-data/testing-tool).