### PR TITLE
Fix ginger edit connection new rsc

### DIFF
--- a/modules/mod_ginger_edit/templates/_action_ginger_dialog_new_rsc_tab.tpl
+++ b/modules/mod_ginger_edit/templates/_action_ginger_dialog_new_rsc_tab.tpl
@@ -1,5 +1,5 @@
 {% with redirect|default:(dispatch=="ginger_edit")|if:[]:`ginger_edit` as redirect %}
-{% with callback|default:(dispatch=="ginger_edit")|if:"zAdminConnectDone":"" as callback %}
+{% with callback|default:"" as callback %}
 {% with actions|default:[] as actions %}
 
 


### PR DESCRIPTION
Removed callback from new rsc template since there is now a live template to show the connected resources. This callback was from a previous version.