### PR TITLE
Importing a db should not stop zotonic but only the site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,11 @@ gulp $(site):
 
 import-db-file $(db) $(file):
 	@echo "> Importing $(db) from $(file)"
-	@docker-compose stop zotonic
-	@docker-compose up -d postgres
+	@docker-compose exec zotonic bin/zotonic stopsite $(db)
 	@docker-compose exec postgres psql -U zotonic -c "DROP DATABASE IF EXISTS $(db)"
 	@docker-compose exec postgres psql -U zotonic -c "CREATE DATABASE $(db) ENCODING 'UTF8' TEMPLATE template0"
 	@docker-compose exec postgres psql $(db) -U zotonic -h localhost -f $(file)
-	$(MAKE) up
+	@docker-compose exec zotonic bin/zotonic startsite $(db)
 
 import-db-backup $(host) $(site):
 	@echo "> Importing $(REMOTE_BACKUP_FILE) from $(host) into $(site)"


### PR DESCRIPTION
I think this is a little less frustrating than having to restart and rebuild all the containers on every DB import.