### PR TITLE
[remark] Do not load TinyMCE JS on all pages

### DIFF
--- a/modules/mod_ginger_remark/templates/_remarks.tpl
+++ b/modules/mod_ginger_remark/templates/_remarks.tpl
@@ -20,27 +20,8 @@
 {% endwith %}
 
 {% javascript %}
-
-    tinyInit.toolbar="styleselect | bold italic | bullist numlist | removeformat | zmedia | link unlink | code";
-
-    tinyInit.style_formats = [  {title: "Headers", items: [
-                                {title: "Header 3", format: "h3"},
-                                {title: "Header 4", format: "h4"},
-                            ]},
-                            {title: "Inline", items: [
-                                {title: "Bold", icon: "bold", format: "bold"},
-                                {title: "Italic", icon: "italic", format: "italic"},
-                                {title: "Underline", icon: "underline", format: "underline"},
-                                {title: "Strikethrough", icon: "strikethrough", format: "strikethrough"},
-                            ]},
-                            {title: "Blocks", items: [
-                                {title: "Paragraph", format: "p"},
-                                {title: "Blockquote", format: "blockquote"},
-                            ]}
-                        ]
     {% if show_form %}
         z_event('new_remark');
     {% endif %}
 
 {% endjavascript %}
-

--- a/modules/mod_ginger_remark/templates/_script.tpl
+++ b/modules/mod_ginger_remark/templates/_script.tpl
@@ -1,6 +1,3 @@
-
-{% include "_editor.tpl" %}
-
 {% lib
     "js/remark_widget.js"
     "js/remarks_widget.js"

--- a/modules/mod_ginger_remark/templates/_tinymce_overrides.tpl
+++ b/modules/mod_ginger_remark/templates/_tinymce_overrides.tpl
@@ -1,0 +1,17 @@
+tinyInit.toolbar="styleselect | bold italic | bullist numlist | removeformat | zmedia | link unlink | code";
+
+tinyInit.style_formats = [  {title: "Headers", items: [
+                            {title: "Header 3", format: "h3"},
+                                {title: "Header 4", format: "h4"},
+                            ]},
+                            {title: "Inline", items: [
+                                {title: "Bold", icon: "bold", format: "bold"},
+                                {title: "Italic", icon: "italic", format: "italic"},
+                                {title: "Underline", icon: "underline", format: "underline"},
+                                {title: "Strikethrough", icon: "strikethrough", format: "strikethrough"},
+                            ]},
+                            {title: "Blocks", items: [
+                                {title: "Paragraph", format: "p"},
+                                {title: "Blockquote", format: "blockquote"},
+                            ]}
+                        ];

--- a/modules/mod_ginger_remark/templates/remark/remark-edit.tpl
+++ b/modules/mod_ginger_remark/templates/remark/remark-edit.tpl
@@ -75,3 +75,5 @@
     {% endjavascript %}
 
 {% endwith %}
+
+{% include "_editor.tpl" overrides_tpl="_tinymce_overrides.tpl" %}


### PR DESCRIPTION
Fix #266.

* Remove from _script.tpl, as it's loaded on all pages.
* Move overrides to custom template.