### PR TITLE
[base] search word in title on search page

### DIFF
--- a/modules/mod_ginger_base/templates/search.tpl
+++ b/modules/mod_ginger_base/templates/search.tpl
@@ -1,6 +1,6 @@
 {% extends "base.tpl" %}
 
-{% block title %}{_ Search _}{% endblock %}
+{% block title %}{_ Search _} | {{ q.qs }}{% endblock %}
 
 {% block body_class %}t--search{% endblock %}
 


### PR DESCRIPTION
Is this ok? "Search | seach word" or do you want "search word | Search"?