### PR TITLE
Clone mod_elasticsearch to fix Ginger build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
     - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
     - chmod +x docker-compose
     - sudo mv docker-compose /usr/local/bin
+    - git clone https://github.com/driebit/mod_elasticsearch.git modules/mod_elasticsearch
 
 script:
     - docker version


### PR DESCRIPTION
Ginger is now dependent on mod_elasticsearch.