### PR TITLE
Add automated browser tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ data/*
 sites/*
 modules/*
 !modules/mod_ginger*
+tests/node_modules
+tests/reports
+tests/screenshots
 *.mo
 *.pot
 .idea

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Documentation
 * [Guidelines](docs/guidelines.md)
 * [Why Ginger is a single Git repository](docs/monorepo.md)
 * [Releases](docs/releases.md)
+* [Browser tests](docs/browser-tests.md)
 * [Templates](docs/templates.md)
 * [Anymeta import](docs/anymeta-import.md)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,27 @@ services:
             MAKE: "true"
             LOGSTASH_HOST: "localhost"
             LOGSTASH_PORT: 5514
+        networks:
+            default:
+            selenium:
+
+    node-tests:
+        image: driebit/node
+        command: test
+        links:
+            - selenium
+        environment:
+            SELENIUM_REMOTE_URL: http://selenium:4444/wd/hub
+        networks:
+            - selenium
+
+    selenium:
+        image: selenium/standalone-chrome:3.4.0
+        networks:
+            - selenium
+
+networks:
+    selenium:
 
 volumes:
     postgres-data: {}

--- a/docs/browser-tests.md
+++ b/docs/browser-tests.md
@@ -1,0 +1,59 @@
+Browser tests
+=============
+
+Ginger ships with an automated end-to-end browser testing setup, batteries 
+included. The tests are written in [Gherkin](https://github.com/cucumber/cucumber/wiki/Gherkin),
+executed by [Nightwatch.js](http://nightwatchjs.org) and run against a 
+Selenium-based headless Chrome instance. 
+
+The setup consists of:
+
+- a `selenium` Docker container with a headless Chrome, so you can run the tests
+  in a CI environment as well
+- a `node-tests` container that contains Nightwatch.js and its WebDriver client 
+  and executes the JavaScript
+- a Nightwatch.js configuration
+- [Cucumber.js](https://github.com/cucumber/cucumber-js) 
+  [step definitions](../../tests/features/step_definitions/) geared towards 
+  Ginger sites. 
+ 
+Writing browser site tests
+--------------------------
+
+In your Ginger site, add a `features/` directory. In this directory, add
+`.feature` files to describe your site’s behaviour. For instance:
+
+```gherkin
+# yoursite/features/homepage.feature
+Feature: homepage
+
+Scenario: homepage title
+
+    When I visit "/"
+    Then the title is "Welcome to my website!"
+```
+
+For more information, consult Ginger’s [step definitions](../../tests/features/step_definitions/)
+and the [Cucumber.js docs](https://github.com/cucumber/cucumber-js).
+
+Running your tests
+------------------
+
+### Run in Docker
+
+To run your tests:
+
+```bash
+$ make test site=yoursite
+```
+
+When a test fails, a screenshot is automatically made and stored in 
+`tests/screenshots`.
+
+### Run locally
+
+To run the tests on a local Chrome instance, so you can see what is happening:
+
+```bash
+$ make test-local site=yoursite
+```

--- a/tests/features/step_definitions/assertions.js
+++ b/tests/features/step_definitions/assertions.js
@@ -1,0 +1,16 @@
+const {client} = require('nightwatch-cucumber');
+const {defineSupportCode} = require('cucumber');
+
+defineSupportCode(({Then}) => {
+    Then(/^the title is "([^"]*)"$/, (title) => {
+        return client.assert.title(title);
+    });
+
+    Then(/^"([^"]*)" contains "([^"]*)"/, (element, text) => {
+        return client.assert.containsText(element, text);
+    });
+
+    Then(/^I should see "([^"]*)"/, (element) => {
+        return client.expect.element(element).to.be.visible;
+    });
+});

--- a/tests/features/step_definitions/forms.js
+++ b/tests/features/step_definitions/forms.js
@@ -1,0 +1,9 @@
+const {client} = require('nightwatch-cucumber');
+const {defineSupportCode} = require('cucumber');
+
+defineSupportCode(({When}) => {
+    When(/^I fill in "([^"]*)" with "([^"]*)"/, (input, text) => {
+        return client
+            .setValue('input[name="' + input + '"]', text);
+    });
+});

--- a/tests/features/step_definitions/hooks.js
+++ b/tests/features/step_definitions/hooks.js
@@ -1,0 +1,9 @@
+const {client} = require('nightwatch-cucumber');
+const {defineSupportCode} = require('cucumber');
+
+defineSupportCode(({After}) => {
+    After(function () {
+        // Close the browser to start the next test with a fresh session.
+        return client.end();
+    });
+});

--- a/tests/features/step_definitions/login.js
+++ b/tests/features/step_definitions/login.js
@@ -1,0 +1,24 @@
+const {client} = require('nightwatch-cucumber');
+const {defineSupportCode} = require('cucumber');
+
+defineSupportCode(({Given}) => {
+    Given(/^I log in with username "([^"]*)" and password "([^"]*)"$/, (username, password) => {
+        return login(username, password, '.login--global-nav');
+    });
+
+    Given(/^I log in with username "([^"]*)" and password "([^"]*)" via "([^"]*)"$/, (username, password, link) => {
+        return login(username, password, link);
+    });
+});
+
+function login(username, password, link) {
+    return client
+        .url(client.launchUrl)
+        .waitForElementVisible(link, 3000)
+        .click(link)
+        .waitForElementVisible('#username', 3000)
+        .setValue('#username', username)
+        .setValue('#password', password)
+        .click('#logon_form button[type="submit"]')
+        .waitForElementNotPresent(link, 3000);
+}

--- a/tests/features/step_definitions/navigation.js
+++ b/tests/features/step_definitions/navigation.js
@@ -1,0 +1,20 @@
+const {client} = require('nightwatch-cucumber');
+const {defineSupportCode} = require('cucumber');
+
+defineSupportCode(({When}) => {
+    When(/^I follow "([^"]*)"/, (linkText) => {
+        return client
+            .useXpath()
+            .click('//a[contains(., "' + linkText + '")]');
+    });
+
+    When(/^I visit "([^"]*)"/, (url) => {
+        return client
+            .url(client.launch_url + url)
+            .waitForElementVisible('body', 5000);
+    });
+
+    When(/^I press "([^"]*)"/, (key) => {
+        return client.keys([client.Keys[key]]);
+    });
+});

--- a/tests/globals.js
+++ b/tests/globals.js
@@ -1,0 +1,27 @@
+let chromedriver = require('chromedriver');
+
+module.exports = {
+    'default': {
+        local: false
+    },
+
+    'chrome': {
+        local: true
+    },
+
+    before: function (done) {
+        if (this.local) {
+            chromedriver.start();
+        }
+
+        done();
+    },
+
+    after: function (done) {
+        if (this.local) {
+            chromedriver.stop();
+        }
+
+        done();
+    }
+};

--- a/tests/nightwatch.conf.js
+++ b/tests/nightwatch.conf.js
@@ -1,0 +1,15 @@
+const LAUNCH_URL = process.env.LAUNCH_URL;
+const FEATURES_PATH = process.env.FEATURES_PATH || '/site/features';
+
+require('nightwatch-cucumber')({
+    cucumberArgs: [
+        '--require',
+        'features/step_definitions',
+        FEATURES_PATH,
+    ]
+});
+
+module.exports = (function (settings) {
+    settings.test_settings.default.launch_url = LAUNCH_URL;
+    return settings;
+})(require('./nightwatch.json'));

--- a/tests/nightwatch.json
+++ b/tests/nightwatch.json
@@ -1,0 +1,29 @@
+{
+    "globals_path": "globals.js",
+    "test_settings": {
+        "default": {
+            "selenium_host": "selenium",
+            "desiredCapabilities": {
+                "browserName": "chrome",
+                "chromeOptions": {
+                    "args": [
+                        "window-size=1200,800"
+                    ]
+                }
+            },
+            "screenshots": {
+                "enabled": true,
+                "on_failure": true,
+                "path": "screenshots"
+            }
+        },
+        "chrome": {
+            "selenium_host": "localhost",
+            "selenium_port": 9515,
+            "default_path_prefix" : "",
+            "desiredCapabilities": {
+                "browserName": "chrome"
+            }
+        }
+    }
+}

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,0 +1,15 @@
+{
+    "name": "ginger-tests",
+    "description": "Ginger test suite",
+    "scripts": {
+        "test": "nightwatch",
+        "test-chrome": "nightwatch --env chrome"
+    },
+    "dependencies": {
+        "chromedriver": "^2.29.0",
+        "cucumber": "^2.0.0-rc.9",
+        "nightwatch": "^0.9.14",
+        "nightwatch-cucumber": "^7.1.2",
+        "selenium-webdriver": "^3.3.0"
+    }
+}


### PR DESCRIPTION
This PR adds an automated browser testing setup POC.

1. This setup is based on JavaScript, as that makes it independent from the backend stack (Erlang for Ginger sites, PHP for some other projects, external APIs for SPAs). JavaScript is the common denominator between our projects. Moreover, it’s the browser’s language.

2. I opt for Selenium WebDriver instead of a headless NodeJS browser (such as PhantomJS). While PhantomJS will execute tests faster, it makes them fail randomly and thus raise tests maintenance costs. Later, when Chrome headless is stable, we should be able to migrate to that relatively easily. 

3. Tests must work both locally (with a view on the automated browser) and on CI for validation.

4. Tests will be stored in each site’s repository, so they’ll be visible to developers and fail as quickly as possible after the commit that caused the error was pushed.

5. These tests can rely on a base testing framework, which will be part of Ginger: a docker-compose config, Makefile and a package.json with the tools of our testing trade. This package.json can eventually be published as a separate NPM package, though that introduces some version management overhead. 

To do:

- [ ] documentation
- [x] choose between Gherkin (high-level) or plain JS (lower-level) as testing language
- [x] choose between (a combination of) [Cucumber](https://github.com/cucumber/cucumber-js) (BDD)/Mocha/Jasmine/Nightwatch as testing framework
- [x] add some tests to one of our sites
- [ ] how to trigger tests based on Zotonic/Ginger releases (see also 4 above)? Commits in those projects can cause test failures as well. We could trigger builds through the GitLab API and specify the Ginger and Zotonic version to test against in environment variables.