### PR TITLE
Restructure config override files so it can be overwritten on site level

### DIFF
--- a/modules/mod_ginger_edit/templates/_admin_tinymce_overrides_js.tpl
+++ b/modules/mod_ginger_edit/templates/_admin_tinymce_overrides_js.tpl
@@ -1,7 +1,19 @@
 /*
 Custom settings to override tiny-init.js.
 */
-tinyInit.language="{{ m.translation.language|default:"en" }}";
-tinyInit.menubar="";
-tinyInit.toolbar="styleselect | bold italic | bullist numlist | removeformat | zlink zmedia | link unlink | code";
-tinyInit.extended_valid_elements="iframe[src|style|width|height|scrolling|marginwidth|marginheight|frameborder]";
+
+if (typeof tinymce_overrides_language === 'undefined' || !tinymce_overrides_language) {
+    tinyInit.language="{{ m.translation.language|default:"en" }}";
+}
+
+if (typeof tinymce_overrides_menubar === 'undefined' || !tinymce_overrides_menubar) {
+    tinyInit.menubar="";
+}
+
+if (typeof tinymce_overrides_toolbar === 'undefined' || !tinymce_overrides_toolbar) {
+    tinyInit.toolbar="styleselect | bold italic | bullist numlist | removeformat | zlink zmedia | link unlink | code";
+}
+
+if (typeof tinymce_overrides_extended_valid_elements === 'undefined' || !tinymce_overrides_extended_valid_elements) {
+    tinyInit.extended_valid_elements="iframe[src|style|width|height|scrolling|marginwidth|marginheight|frameborder]";
+}

--- a/modules/mod_ginger_edit/templates/_admin_tinymce_overrides_js.tpl
+++ b/modules/mod_ginger_edit/templates/_admin_tinymce_overrides_js.tpl
@@ -2,7 +2,7 @@
 Custom settings to override tiny-init.js.
 */
 
-if (typeof tinymce_overrides_language === 'undefined' || !tinymce_overrides_language) {
+if (typeof tinyInit.language === 'undefined') {
     tinyInit.language="{{ m.translation.language|default:"en" }}";
 }
 
@@ -14,6 +14,4 @@ if (typeof tinymce_overrides_toolbar === 'undefined' || !tinymce_overrides_toolb
     tinyInit.toolbar="styleselect | bold italic | bullist numlist | removeformat | zlink zmedia | link unlink | code";
 }
 
-if (typeof tinymce_overrides_extended_valid_elements === 'undefined' || !tinymce_overrides_extended_valid_elements) {
-    tinyInit.extended_valid_elements="iframe[src|style|width|height|scrolling|marginwidth|marginheight|frameborder]";
-}
+tinyInit.extended_valid_elements+="iframe[src|style|width|height|scrolling|marginwidth|marginheight|frameborder]";

--- a/modules/mod_ginger_remark/templates/_tinymce_overrides.tpl
+++ b/modules/mod_ginger_remark/templates/_tinymce_overrides.tpl
@@ -2,7 +2,7 @@ if (typeof tinymce_overrides_toolbar === 'undefined' || !tinymce_overrides_toolb
    tinyInit.toolbar="styleselect | bold italic | bullist numlist | removeformat | zmedia | link unlink | code";
 }
 
-if (typeof tinymce_overrides_style_formats === 'undefined' || !tinymce_overrides_style_formats) {
+if (typeof tinyInit.style_formats === 'undefined') {
     tinyInit.style_formats = [  {title: "Headers", items: [
                                 {title: "Header 3", format: "h3"},
                                     {title: "Header 4", format: "h4"},

--- a/modules/mod_ginger_remark/templates/_tinymce_overrides.tpl
+++ b/modules/mod_ginger_remark/templates/_tinymce_overrides.tpl
@@ -1,17 +1,21 @@
-tinyInit.toolbar="styleselect | bold italic | bullist numlist | removeformat | zmedia | link unlink | code";
+if (typeof tinymce_overrides_toolbar === 'undefined' || !tinymce_overrides_toolbar) {
+   tinyInit.toolbar="styleselect | bold italic | bullist numlist | removeformat | zmedia | link unlink | code";
+}
 
-tinyInit.style_formats = [  {title: "Headers", items: [
-                            {title: "Header 3", format: "h3"},
-                                {title: "Header 4", format: "h4"},
-                            ]},
-                            {title: "Inline", items: [
-                                {title: "Bold", icon: "bold", format: "bold"},
-                                {title: "Italic", icon: "italic", format: "italic"},
-                                {title: "Underline", icon: "underline", format: "underline"},
-                                {title: "Strikethrough", icon: "strikethrough", format: "strikethrough"},
-                            ]},
-                            {title: "Blocks", items: [
-                                {title: "Paragraph", format: "p"},
-                                {title: "Blockquote", format: "blockquote"},
-                            ]}
-                        ];
+if (typeof tinymce_overrides_style_formats === 'undefined' || !tinymce_overrides_style_formats) {
+    tinyInit.style_formats = [  {title: "Headers", items: [
+                                {title: "Header 3", format: "h3"},
+                                    {title: "Header 4", format: "h4"},
+                                ]},
+                                {title: "Inline", items: [
+                                    {title: "Bold", icon: "bold", format: "bold"},
+                                    {title: "Italic", icon: "italic", format: "italic"},
+                                    {title: "Underline", icon: "underline", format: "underline"},
+                                    {title: "Strikethrough", icon: "strikethrough", format: "strikethrough"},
+                                ]},
+                                {title: "Blocks", items: [
+                                    {title: "Paragraph", format: "p"},
+                                    {title: "Blockquote", format: "blockquote"},
+                                ]}
+                            ];
+}


### PR DESCRIPTION
Currently it it impossible to override tinymce templates within site level. The override templates are all included with the editor.

The all include loads the site template first, then the module template. So the options in the module template can never be changed by the site template.

The idea is that we can set a parameter on site level and check that on module level to see if the module should add configuration or not.