### PR TITLE
Languages other then en/nl/ru default to en

### DIFF
--- a/modules/mod_ginger_edit/templates/_admin_tinymce_overrides_js.tpl
+++ b/modules/mod_ginger_edit/templates/_admin_tinymce_overrides_js.tpl
@@ -3,7 +3,13 @@ Custom settings to override tiny-init.js.
 */
 
 if (typeof tinyInit.language === 'undefined') {
-    tinyInit.language="{{ m.translation.language|default:"en" }}";
+    {% if m.config.mod_editor_tinymce.version.value < '4.0' %}
+        tinyInit.language="en";
+    {% elseif z_language != `en` and z_language != `nl` and z_language != `ru` %}
+        tinyInit.language="en";
+    {% else %}
+        tinyInit.language="{{ z_language|default:"en" }}";
+    {% endif %}
 }
 
 if (typeof tinymce_overrides_menubar === 'undefined' || !tinymce_overrides_menubar) {


### PR DESCRIPTION
Setting the admin language switch to another language then nl/en/ru causes a 404 on
/lib/js/tinymce-4.3.7/tinymce/plugins/langs/##.js
there are only 3 language javascripts