### PR TITLE
Search suggestions update

### DIFF
--- a/modules/mod_ginger_base/lib/js/base.js
+++ b/modules/mod_ginger_base/lib/js/base.js
@@ -1,99 +1,60 @@
-(function($) {
-    'use strict';
+$.widget("ui.base", {
 
-    $.widget("ui.base", {
-
-        _init: function() {
-            this.init();
-        },
-
-        init: function() {
-            var me = this,
-                element = me.element;
-
-            //fancybox
-            $(".lightbox").fancybox({
-                'openEffect': "fade",
-                'autoSize': true,
-                'autoScale': true,
-                'margin': 50,
-                'autoCenter': true,
-                'autoResize': true,
-                'fitToView': true,
-                'tpl': {
-                        error    : '<p class="fancybox-error"></p>'
-                },
-                'helpers': {
-                    'overlay': {
-                        'css': {
-                            'background': 'rgba(246, 246, 246, 0.75)'
-                        },
-                        locked: false
+    _init: function() {
+        $(".lightbox").fancybox({
+            'openEffect': "fade",
+            'autoSize': true,
+            'autoScale': true,
+            'margin': 50,
+            'autoCenter': true,
+            'autoResize': true,
+            'fitToView': true,
+            'tpl': {
+                    error    : '<p class="fancybox-error"></p>'
+            },
+            'helpers': {
+                'overlay': {
+                    'css': {
+                        'background': 'rgba(246, 246, 246, 0.75)'
                     },
-                    media: {},
-                    'title': {
-                        type: 'inside'
-                    }
+                    locked: false
                 },
-                afterShow: function() {
-
-                    var el = $(this.element),
-                        fbInner = $(".fancybox-inner");
-
-                    if (el.hasClass('default-video-player')) {
-                        var url = el.data('video-url'),
-                            height = el.data('video-height'),
-                            width = el.data('video-width'),
-                            videoHTML = '<video width="' + width +'" height="' + height + '" controls>' +
-                              '<source src="' + url + '">' +
-                              '</video>';
-
-                        $('.fancybox-inner').hide();
-                        $(".fancybox-inner").html(videoHTML);
-                        $('.fancybox-inner').show();
-                        $.fancybox.update();
-                    }
+                media: {},
+                'title': {
+                    type: 'inside'
                 }
-            });
+            },
+            afterShow: function() {
 
-            $(document).on('click', $.proxy(me._documentClick, me));
-            $(document).on('touchend', $.proxy(me._documentClick, me));
-            $(document).on('keyup', $.proxy(me._documentKeyUp, me));
+                var el = $(this.element),
+                    fbInner = $(".fancybox-inner");
 
-        },
+                if (el.hasClass('default-video-player')) {
+                    var url = el.data('video-url'),
+                        height = el.data('video-height'),
+                        width = el.data('video-width'),
+                        videoHTML = '<video width="' + width +'" height="' + height + '" controls>' +
+                            '<source src="' + url + '">' +
+                            '</video>';
 
-        _documentClick: function(event) {
-
-            var me = this;
-
-            if (!$(event.target).closest('form[role="search"]').length) {
-
-                var searchWidgets = $(':ui-search_suggestions'),
-                    isOpen = false;
-
-                $.each(searchWidgets, function(i, widget) {
-
-                    var inst = $(widget).data('ui-search_suggestions');
-                    if (inst && inst.isVisible()) {
-                        isOpen = true;
-                    }
-                });
-
-                if (isOpen) {
-                    $(document).trigger('search:close');
+                    $('.fancybox-inner').hide();
+                    $(".fancybox-inner").html(videoHTML);
+                    $('.fancybox-inner').show();
+                    $.fancybox.update();
                 }
             }
+        });
 
-        },
+        this._addEventListeners();
+    },
 
-        _documentKeyUp: function(event) {
+    _addEventListeners: function() {
+        $(document).on('keyup', this._documentKeyUp.bind(this));
+    },
 
-            if (event.keyCode == 27) {
-                $(document).trigger('search:close');
-                $(document).trigger('menu:close');
-            }
+    _documentKeyUp: function(event) {
+        if (event.keyCode == 27) {
+            $(document).trigger('menu:close');
         }
-
-
-    });
-})(jQuery);
+    }
+});

--- a/modules/mod_ginger_base/lib/js/search-suggestions.js
+++ b/modules/mod_ginger_base/lib/js/search-suggestions.js
@@ -1,10 +1,6 @@
 $.widget("ui.search_suggestions", {
 
     _init: function() {
-        this.init();
-    },
-
-    init: function() {
         // Initial model
         this.model = {
             index: -1,
@@ -83,30 +79,38 @@ $.widget("ui.search_suggestions", {
     },
 
     _render: function() {
+        // Reset all applied styles
         this._removeHighlight();
 
         if (this.model.index === -1 || this.model.suggestions.length === 0) {
             return;
         }
 
+        // Style/highlight selected element
         this.model.suggestions[this.model.index].style.textDecoration = 'underline';
         this.model.suggestions[this.model.index].style.fontWeight = '800';
 
+        // Change the input value to the selected suggestion value
         this.element[0].value = this.model.suggestions[this.model.index].textContent.trim();
     },
 
     _attachEventListeners: function() {
         var document = $(document);
+        var mainElement = $('main');
 
-        document.on('search:close', this._hideInputElement.bind(this));
+        document.on('touchend', this._hideInputElement.bind(this));
+
+        document.on('search:close', () => console.log("wejf"));
 
         document.on('search:toggle', this._toggleInputElementVisibility.bind(this));
 
-        document.on('keyup', function(e) {
-            if (e.keyCode === 13) {
+        document.on('keyup', function(event) {
+            if (event.keyCode === 13) {
                 this._hideInputElement();
             }
         }.bind(this));
+
+        mainElement.on('click', this._hideInputElement.bind(this));
 
         this.element.on('keyup', function(e) {
             var key = e.keyCode;
@@ -161,23 +165,23 @@ $.widget("ui.search_suggestions", {
         this._toggleInputElementVisibility(event, true);
     },
 
-    _toggleInputElementVisibility: function(event, close) {
-        if (this.toggleButtonElement) {
-            this.toggleButtonElement.toggleClass('is-active');
+    _toggleInputElementVisibility: function(event, hideElement) {
+        if (this.toggleButtonElement !== undefined) {
+            if (hideElement) {
+                this.toggleButtonElement.removeClass('is-active');
+            } else {
+                this.toggleButtonElement.toggleClass('is-active');
+            }
         }
 
-        if (close) {
-            this.suggestionsElement.hide();
+        if (hideElement) {
             this.formElement.removeClass('is-visible');
-
-            if (this.toggleButtonElement) {
-                this.toggleButtonElement.removeClass('is-active');
-            }
+            this.suggestionsElement.hide();
         } else {
             this.formElement.toggleClass('is-visible');
         }
 
-        if (this._isVisible()) {
+        if (this.isVisible()) {
             this.formElement.on('transitionend', function () {
                 this.element.focus();
             }.bind(this));
@@ -187,10 +191,9 @@ $.widget("ui.search_suggestions", {
 
         this.element.val('');
         this.suggestionsElement.hide();
-        return false; // Don't know about this
     },
 
-    _isVisible: function() {
+    isVisible: function() {
         return this.suggestionsElement.css('display') === 'block' ||
         this.formElement.hasClass('is-visible');
     }

--- a/modules/mod_ginger_base/lib/js/search-suggestions.js
+++ b/modules/mod_ginger_base/lib/js/search-suggestions.js
@@ -165,7 +165,7 @@ $.widget("ui.search_suggestions", {
     },
 
     _focusFormElement: function() {
-        if (this._isVisible()) {
+        if (this.isVisible()) {
             this.element.focus();
         }
     },
@@ -191,7 +191,7 @@ $.widget("ui.search_suggestions", {
         this.element.val('');
     },
 
-    _isVisible: function() {
+    isVisible: function() {
         return this.suggestionsElement.css('display') === 'block' ||
         this.formElement.hasClass('is-visible');
     }

--- a/modules/mod_ginger_base/lib/js/search-suggestions.js
+++ b/modules/mod_ginger_base/lib/js/search-suggestions.js
@@ -29,6 +29,9 @@ $.widget("ui.search_suggestions", {
         // Attach EventListeners
         this._attachEventListeners();
 
+        // Hide suggestions by default
+        this.suggestionsElement.hide();
+
         // Don't know why this was here... yet
         // this.suggestionsElement.removeClass('is-scrolable');
         // this.suggestionsElement.hide();

--- a/modules/mod_ginger_base/lib/js/search-suggestions.js
+++ b/modules/mod_ginger_base/lib/js/search-suggestions.js
@@ -34,7 +34,6 @@ $.widget("ui.search_suggestions", {
 
         // Don't know why this was here... yet
         // this.suggestionsElement.removeClass('is-scrolable');
-        // this.suggestionsElement.hide();
     },
 
     // If possible update the model through by use of this function
@@ -197,7 +196,7 @@ $.widget("ui.search_suggestions", {
         this.element.val('');
     },
 
-    //
+    // Public method to check if suggestions element is visible
     isVisible: function() {
         return this.suggestionsElement.css('display') === 'block' ||
         this.formElement.hasClass('is-visible');

--- a/modules/mod_ginger_base/lib/js/search-suggestions.js
+++ b/modules/mod_ginger_base/lib/js/search-suggestions.js
@@ -16,6 +16,9 @@ $.widget("ui.search_suggestions", {
         var suggestionsElementId = this.element.data('param-results');
         this.suggestionsElement = $('#' + suggestionsElementId);
 
+        // Hide suggestions by default
+        this.suggestionsElement.hide();
+
         // Set search form toggle element
         var toggleButtonId = this.element.data('param-togglebutton');
         this.toggleButtonElement = $('#' + toggleButtonId);
@@ -29,16 +32,13 @@ $.widget("ui.search_suggestions", {
         // Attach EventListeners
         this._attachEventListeners();
 
-        // Hide suggestions by default
-        this.suggestionsElement.hide();
-
         // Don't know why this was here... yet
         // this.suggestionsElement.removeClass('is-scrolable');
         // this.suggestionsElement.hide();
     },
 
     // If possible update the model through by use of this function
-    update: function(type, value) {
+    _update: function(type, value) {
         switch (type) {
             case 'SetSuggestions':
                 this.model.index = -1;
@@ -83,6 +83,7 @@ $.widget("ui.search_suggestions", {
         // Reset all applied styles
         this._removeHighlight();
 
+        // Test if selection is at the end of the suggestion list
         if (this.model.index === -1 || this.model.suggestions.length === 0) {
             return;
         }
@@ -117,13 +118,13 @@ $.widget("ui.search_suggestions", {
             var inputValue = e.currentTarget.value;
 
             if (key === 38) {
-                this.update('MoveUp', inputValue);
+                this._update('MoveUp', inputValue);
             } else if (key === 40) {
-                this.update('MoveDown', inputValue);
+                this._update('MoveDown', inputValue);
             } else if (key === 27) {
                 this._hideInputElement();
             } else {
-                this.update('SetInput', inputValue);
+                this._update('SetInput', inputValue);
             }
         }.bind(this));
 
@@ -134,6 +135,7 @@ $.widget("ui.search_suggestions", {
         }
     },
 
+    // Send input value over Zotonic wire
     _getSuggestions: function() {
         z_event(this.suggestionsWire, { value: this.model.input });
 
@@ -142,10 +144,11 @@ $.widget("ui.search_suggestions", {
         }
     },
 
+    // Observe suggestions element for changes rendered by Zotonic
     _observeSuggestions: function() {
         var observer = new MutationObserver(function(mutations) {
             mutations.forEach(function(mutation) {
-                this.update('SetSuggestions', mutation.target.querySelectorAll('a'));
+                this._update('SetSuggestions', mutation.target.querySelectorAll('a'));
             }.bind(this));
         }.bind(this));
 
@@ -194,6 +197,7 @@ $.widget("ui.search_suggestions", {
         this.element.val('');
     },
 
+    //
     isVisible: function() {
         return this.suggestionsElement.css('display') === 'block' ||
         this.formElement.hasClass('is-visible');

--- a/modules/mod_ginger_base/lib/js/search-suggestions.js
+++ b/modules/mod_ginger_base/lib/js/search-suggestions.js
@@ -1,205 +1,196 @@
-(function ($) {
-   'use strict';
+$.widget("ui.search_suggestions", {
 
-    $.widget("ui.search_suggestions", {
+    _init: function() {
+        this.init();
+    },
 
-        model: {
+    init: function() {
+        // Initial model
+        this.model = {
             index: -1,
             suggestions: [],
             input: ''
-        },
-
-         update: function(type, value) {
-            switch (type) {
-                case 'SetSuggestions': {
-                    this.model.index = -1;
-                    this.model.suggestions = Array.prototype.slice.call(value);
-                    this.render();
-                }
-                break;
-
-                case 'MoveDown': {
-                    if (this.model.index === this.model.suggestions.length - 1) {
-                        this.model.index = 0;
-                    } else {
-                        this.model.index = this.model.index + 1;
-                        this.model.value = value;
-                    }
-                    this.render();
-                }
-                break;
-
-                case 'MoveUp': {
-                    if (this.model.index === -1) {
-                         this.model.index = this.model.suggestions.length - 1;
-                    } else {
-                        this.model.index = this.model.index - 1;
-                        this.model.value = value;
-                    }
-                    this.render();
-                }
-                break;
-
-                case 'SetInput': {
-                    this.model.input = value;
-                }
-                break;
-
-                case 'OnReturnPressed': {
-                    this._closeSearch();
-                }
-                break;
-            }
-        },
-
-        render: function() {
-            this._removeHighlight();
-
-            if (this.model.index === -1 || this.model.suggestions.length === 0) {
-                return;
-            }
-
-            this.model.suggestions[this.model.index].style.textDecoration = 'underline';
-            this.model.suggestions[this.model.index].style.fontWeight = '800';
-
-            this.element[0].value = this.model.suggestions[this.model.index].textContent.trim();
-        },
-
-        _init: function() {
-            this.init();
-        },
-
-        init: function() {
-
-            var me = this,
-                element = me.element,
-                timer = null,
-                prevVal = null,
-                paramResults = element.data('param-results'),
-                paramWire = element.data('param-wire'),
-                paramToggleButton = '#' + element.data('param-togglebutton'),
-                windowHeight = $(window).height();
-
-                me.toggleButton         = $(paramToggleButton),
-                me.searchForm           = $(element.closest('form')),
-                me.searchInput          = element,
-                me.suggestions          = $('#' + paramResults);
-
-            me.suggestions.removeClass('is-scrolable');
-            me.suggestions.hide();
-
-            var target = document.querySelector('.search-suggestions__suggestions')
-
-            var observer = new MutationObserver(function(mutations) {
-                mutations.forEach(function(mutation) {
-                    me.update('SetSuggestions', mutation.target.querySelectorAll('a'));
-                });
-            });
-
-            // configuration of the observer:
-            var config = { attributes: true, childList: true, characterData: true };
-
-            // pass in the target node, as well as the observer options
-            observer.observe(target, config);
-
-
-            function doSearch() {
-
-                var val = me.element.val();
-
-                if (val.length == 0) {
-                    me.suggestions.hide();
-                    return;
-                }
-
-                z_event(paramWire, {value: val});
-
-                setTimeout(function(){
-                    me.suggestions.show(0, function() {
-                        if (me.suggestions.outerHeight() > windowHeight) {
-                            me.suggestions.addClass('is-scrollable');
-                        }
-                    });
-                }, 500);
-
-            }
-
-            $(document).on('keyup', function(e) {
-                if (e.keyCode === 13) {
-                    me.update('OnReturnPressed');
-                }
-            });
-
-            me.element.on('keyup', function(e) {
-                var key = e.keyCode;
-                var inputValue = e.currentTarget.value;
-
-                if (key === 38) {
-                    me.update('MoveUp', inputValue);
-                } else if (key === 40) {
-                    me.update('MoveDown', inputValue);
-                } else {
-                    me.update('SetInput', inputValue);
-                    doSearch();
-                }
-            });
-
-            $(document).on('search:close', $.proxy(me._closeSearch, me));
-            $(document).on('search:toggle', $.proxy(me._toggleSearch, me));
-
-            if (me.toggleButton != undefined) me.toggleButton.on('click', $.proxy(me._toggleSearch, me));
-
-        },
-
-        _removeHighlight: function() {
-            this.model.suggestions.forEach(function(x) {
-                x.style.textDecoration = 'none';
-                x.style.fontWeight = '400';
-            });
-        },
-
-        _closeSearch: function(event) {
-            var me = this;
-            me._toggleSearch(event, true);
-        },
-
-        _toggleSearch: function(event, close) {
-
-            var me = this;
-
-            if (me.toggleButton) me.toggleButton.toggleClass('is-active');
-
-            if(close) {
-                me.suggestions.hide();
-                me.searchForm.removeClass('is-visible');
-                if (me.toggleButton) me.toggleButton.removeClass('is-active');
-            } else {
-                me.searchForm.toggleClass('is-visible');
-            }
-
-            me.searchInput.val('');
-            me.suggestions.hide();
-
-            if (me.isVisible()) {
-                me.searchForm.on('transitionend', function () {
-                    me.searchInput.focus();
-                });
-            }
-
-            $(document).trigger('search:toggled');
-
-            return false;
-        },
-
-        isVisible: function() {
-
-            var me = this;
-
-            if (me.suggestions.css('display') == 'block' || me.searchForm.hasClass('is-visible')) {
-                return true;
-            } else {
-                return false;
-            }
         }
-    });
-})(jQuery);
+
+        // Zotonic wire ID that sends search value
+        this.suggestionsWire = this.element.data('param-wire');
+
+        // Set Viewport height
+        this.windowHeight = $(window).height();
+
+        // Set suggestions element
+        var suggestionsElementId = this.element.data('param-results');
+        this.suggestionsElement = $('#' + suggestionsElementId);
+
+        // Set search form toggle element
+        var toggleButtonId = this.element.data('param-togglebutton');
+        this.toggleButtonElement = $('#' + toggleButtonId);
+
+        // Set form element
+        this.formElement = this.element.closest('form');
+
+        // Initialize MutationObserver
+        this._observeSuggestions();
+
+        // Attach EventListeners
+        this._attachEventListeners();
+
+        // Don't know why this was here... yet
+        // this.suggestionsElement.removeClass('is-scrolable');
+        // this.suggestionsElement.hide();
+    },
+
+    update: function(type, value) {
+        switch (type) {
+            case 'SetSuggestions':
+                this.model.index = -1;
+                this.model.suggestions = Array.prototype.slice.call(value);
+                this._render();
+                break;
+
+            case 'MoveDown':
+                if (this.model.index === this.model.suggestions.length - 1) {
+                    this.model.index = 0;
+                } else {
+                    this.model.index = this.model.index + 1;
+                    this.model.value = value;
+                }
+                this._render();
+                break;
+
+            case 'MoveUp':
+                if (this.model.index === -1) {
+                        this.model.index = this.model.suggestions.length - 1;
+                } else {
+                    this.model.index = this.model.index - 1;
+                    this.model.value = value;
+                }
+                this._render();
+                break;
+
+            case 'SetInput':
+                this.model.input = value;
+
+                if (value.trim() !== '') {
+                    this._getSuggestions(value);
+                    this.suggestionsElement.show();
+                } else {
+                    this.suggestionsElement.hide();
+                }
+                break;
+        }
+    },
+
+    _render: function() {
+        this._removeHighlight();
+
+        if (this.model.index === -1 || this.model.suggestions.length === 0) {
+            return;
+        }
+
+        this.model.suggestions[this.model.index].style.textDecoration = 'underline';
+        this.model.suggestions[this.model.index].style.fontWeight = '800';
+
+        this.element[0].value = this.model.suggestions[this.model.index].textContent.trim();
+    },
+
+
+    _attachEventListeners: function() {
+        var document = $(document);
+
+        document.on('search:close', this._closeSearch.bind(this));
+
+        document.on('search:toggle', this._toggleSearch.bind(this));
+
+        document.on('keyup', function(e) {
+            if (e.keyCode === 13) {
+                this._closeSearch();
+            }
+        }.bind(this));
+
+        this.element.on('keyup', function(e) {
+            var key = e.keyCode;
+            var inputValue = e.currentTarget.value;
+
+            if (key === 38) {
+                this.update('MoveUp', inputValue);
+            } else if (key === 40) {
+                this.update('MoveDown', inputValue);
+            } else if (key === 27) {
+                this._closeSearch();
+            } else {
+                this.update('SetInput', inputValue);
+            }
+        }.bind(this));
+
+        if (this.toggleButtonElement !== undefined) {
+            this.toggleButtonElement.on('click', this._toggleSearch.bind(this));
+        }
+    },
+
+        _getSuggestions: function() {
+        z_event(this.suggestionsWire, {value: this.model.input});
+
+        if (this.suggestionsElement.outerHeight() > this.windowHeight) {
+            this.suggestionsElement.addClass('is-scrollable');
+        }
+    },
+
+    _observeSuggestions: function() {
+        var observer = new MutationObserver(function(mutations) {
+            mutations.forEach(function(mutation) {
+                this.update('SetSuggestions', mutation.target.querySelectorAll('a'));
+            }.bind(this));
+        }.bind(this));
+
+        // configuration of the observer:
+        var config = { attributes: true, childList: true, characterData: true };
+
+        // pass in the target node, as well as the observer options
+        observer.observe(this.suggestionsElement[0], config);
+    },
+
+    _removeHighlight: function() {
+        this.model.suggestions.forEach(function(x) {
+            x.style.textDecoration = 'none';
+            x.style.fontWeight = '400';
+        });
+    },
+
+    _closeSearch: function(event) {
+        this._toggleSearch(event, true);
+    },
+
+    _toggleSearch: function(event, close) {
+        if (this.toggleButtonElement) {
+            this.toggleButtonElement.toggleClass('is-active');
+        }
+
+        if (close) {
+            this.suggestionsElement.hide();
+            this.formElement.removeClass('is-visible');
+            if (this.toggleButtonElement) this.toggleButtonElement.removeClass('is-active');
+        } else {
+            this.formElement.toggleClass('is-visible');
+        }
+
+        this.element.val('');
+        this.suggestionsElement.hide();
+
+        if (this._isVisible()) {
+            this.formElement.on('transitionend', function () {
+                this.element.focus();
+            }.bind(this));
+        }
+
+        $(document).trigger('search:toggled');
+
+        return false; // Don't know about this
+    },
+
+    _isVisible: function() {
+        return this.suggestionsElement.css('display') === 'block' ||
+        this.formElement.hasClass('is-visible');
+    }
+});
+

--- a/modules/mod_ginger_base/lib/js/search-suggestions.js
+++ b/modules/mod_ginger_base/lib/js/search-suggestions.js
@@ -100,8 +100,6 @@ $.widget("ui.search_suggestions", {
 
         document.on('touchend', this._hideInputElement.bind(this));
 
-        document.on('search:close', () => console.log("wejf"));
-
         document.on('search:toggle', this._toggleInputElementVisibility.bind(this));
 
         document.on('keyup', function(event) {

--- a/modules/mod_ginger_base/lib/js/search-suggestions.js
+++ b/modules/mod_ginger_base/lib/js/search-suggestions.js
@@ -40,6 +40,7 @@ $.widget("ui.search_suggestions", {
         // this.suggestionsElement.hide();
     },
 
+    // If possible update the model through by use of this function
     update: function(type, value) {
         switch (type) {
             case 'SetSuggestions':
@@ -94,17 +95,16 @@ $.widget("ui.search_suggestions", {
         this.element[0].value = this.model.suggestions[this.model.index].textContent.trim();
     },
 
-
     _attachEventListeners: function() {
         var document = $(document);
 
-        document.on('search:close', this._closeSearch.bind(this));
+        document.on('search:close', this._hideInputElement.bind(this));
 
-        document.on('search:toggle', this._toggleSearch.bind(this));
+        document.on('search:toggle', this._toggleInputElementVisibility.bind(this));
 
         document.on('keyup', function(e) {
             if (e.keyCode === 13) {
-                this._closeSearch();
+                this._hideInputElement();
             }
         }.bind(this));
 
@@ -117,18 +117,18 @@ $.widget("ui.search_suggestions", {
             } else if (key === 40) {
                 this.update('MoveDown', inputValue);
             } else if (key === 27) {
-                this._closeSearch();
+                this._hideInputElement();
             } else {
                 this.update('SetInput', inputValue);
             }
         }.bind(this));
 
         if (this.toggleButtonElement !== undefined) {
-            this.toggleButtonElement.on('click', this._toggleSearch.bind(this));
+            this.toggleButtonElement.on('click', this._toggleInputElementVisibility.bind(this));
         }
     },
 
-        _getSuggestions: function() {
+    _getSuggestions: function() {
         z_event(this.suggestionsWire, {value: this.model.input});
 
         if (this.suggestionsElement.outerHeight() > this.windowHeight) {
@@ -143,10 +143,10 @@ $.widget("ui.search_suggestions", {
             }.bind(this));
         }.bind(this));
 
-        // configuration of the observer:
+        // Configuration of the observer:
         var config = { attributes: true, childList: true, characterData: true };
 
-        // pass in the target node, as well as the observer options
+        // Pass in the target node, as well as the observer options
         observer.observe(this.suggestionsElement[0], config);
     },
 
@@ -157,11 +157,11 @@ $.widget("ui.search_suggestions", {
         });
     },
 
-    _closeSearch: function(event) {
-        this._toggleSearch(event, true);
+    _hideInputElement: function(event) {
+        this._toggleInputElementVisibility(event, true);
     },
 
-    _toggleSearch: function(event, close) {
+    _toggleInputElementVisibility: function(event, close) {
         if (this.toggleButtonElement) {
             this.toggleButtonElement.toggleClass('is-active');
         }
@@ -169,13 +169,13 @@ $.widget("ui.search_suggestions", {
         if (close) {
             this.suggestionsElement.hide();
             this.formElement.removeClass('is-visible');
-            if (this.toggleButtonElement) this.toggleButtonElement.removeClass('is-active');
+
+            if (this.toggleButtonElement) {
+                this.toggleButtonElement.removeClass('is-active');
+            }
         } else {
             this.formElement.toggleClass('is-visible');
         }
-
-        this.element.val('');
-        this.suggestionsElement.hide();
 
         if (this._isVisible()) {
             this.formElement.on('transitionend', function () {
@@ -185,6 +185,8 @@ $.widget("ui.search_suggestions", {
 
         $(document).trigger('search:toggled');
 
+        this.element.val('');
+        this.suggestionsElement.hide();
         return false; // Don't know about this
     },
 
@@ -193,4 +195,3 @@ $.widget("ui.search_suggestions", {
         this.formElement.hasClass('is-visible');
     }
 });
-


### PR DESCRIPTION
- Added comments
- Re-ordered methods (which is why it looks like I rewrote _everything_)
- Break methods apart to improve readability
- Indicate which methods are public by `_` convention
- Removed `me = this` and use `this`
- Replaced `$.proxy` with `bind()`, which is native and recommended by jQuery as well
- Removed wrapping of widget in a closure, which had no effect
- Replaced `_init(){ this.init() };`, `_init(){ ... };`. jQueryUI calls `_created` and `_init`, I don't see the advantage of having a separate `init` over the default
- Move `base.js` eventlistener to `search-suggestions.js` since it was it's dependancy and makes more sense to be attached by itself
- Use element-ids declared at template `do_...` to get other elements from dom