### PR TITLE
[docker] Build driebit/ginger from main repo

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+data/
+docs/
+sites**/
+scripts/
+skel/
+tests/

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -1,0 +1,18 @@
+ARG ZOTONIC_VERSION=0.x
+FROM zotonic/zotonic:${ZOTONIC_VERSION}
+
+ADD . /opt/ginger
+COPY docker/prod/etc_zotonic /etc/zotonic
+
+WORKDIR /opt/zotonic
+
+RUN apk add --virtual build-deps --no-cache $BUILD_APKS \
+	&& apk add --no-cache s6 bash \
+	&& DEBUG=1 make \
+	&& apk del build-deps
+
+RUN chown -R zotonic /opt/ginger
+
+COPY docker/prod/s6 /etc/s6
+
+CMD s6-svscan /etc/s6

--- a/docker/prod/etc_zotonic/erlang.config
+++ b/docker/prod/etc_zotonic/erlang.config
@@ -1,0 +1,77 @@
+%% -*- mode: erlang -*-
+[
+
+% Since zotonic is not distributed, listen for epmd on 127.0.0.1.
+{kernel,
+  [
+   {inet_dist_use_interface, {127,0,0,1}}
+  ]
+ },
+
+ {exometer, [{predefined, [
+    {[erlang, memory], {function, erlang, memory, [], value, []}, []},
+    {[erlang, system_info], {function, erlang, system_info, ['$dp'], value, [process_count]}, []},
+    {[erlang, statistics], {function, erlang, statistics, ['$dp'], value, [run_queue]}, []},
+    {[erlang, io], {function, erlang, statistics, [io], match, {{'_', input}, {'_', output}}}, []}
+   ]}
+ ]},
+
+ {mnesia, [
+    {dir, "priv/mnesia"}
+ ]},
+
+ {emqtt, [
+    {auth, {zotonic, []}},
+    {access_control, {zotonic, []}},
+    {listeners, [
+        %%% Unescape to enable MQTT on the given port
+        % {1883,  [
+        %     binary,
+        %     {packet,        raw},
+        %     {reuseaddr,     true},
+        %     {backlog,       128},
+        %     {nodelay,       true}
+        % ]}
+    ]}
+ ]},
+
+ {lager,
+  [{handlers,
+    [
+      {lager_console_backend, info}
+    ]},
+   {crash_log, "priv/log/crash.log"}
+  ]},
+
+ {webzmachine,
+  [
+%%% Logger module, use this option to set your own.
+   %% {webmachine_logger_module, z_stats}, % <- default set by Zotonic
+   %% {webmachine_logger_module, webmachine_logger}, % <- webmachine default
+
+%%% Error handler module, use this option to set your own.
+   %% {error_handler, z_webmachine_error_handler}, % <- default set by Zotonic
+   %% {error_handler, webmachine_error_handler}, % <- webmachine default
+
+%%% Set this option to false if you want webmachine to write info about
+%%% opening/closing log files to the Erlang console.
+   %% {silent_console, true},
+
+%%% Location of access logs (logging is disabled if not set).
+%   {log_dir, "priv/log/access/"},
+
+%%% Location of performance logs (logging is disabled if not set).
+   %% {perf_log_dir, "priv/log/perf/"},
+
+%%% Location of wmtrace logs (defaults to "priv/wmtrace" if not specified).
+   {wmtrace_dir, "priv/log/wmtrace/"},
+
+%%% Which sendfile command to use: disable, yaws, erlang
+   {use_sendfile, erlang}
+
+  ]},
+
+    {erlastic_search, [
+        {host, <<"elasticsearch">>}
+    ]}
+].

--- a/docker/prod/etc_zotonic/zotonic.config
+++ b/docker/prod/etc_zotonic/zotonic.config
@@ -1,0 +1,13 @@
+[{zotonic, [
+    {dbhost, "postgres"},
+    {elasticsearch_host, <<"elasticsearch">>},
+    {password, ""},
+    {user_modules_dir, "/opt/ginger/modules"},
+    {user_sites_dir, "/opt/ginger/sites"},
+    {deps, [
+        {erlastic_search, ".*", {git, "https://github.com/tsloughter/erlastic_search.git", "6478cc5d915413a7162515a19fa705296c605823"}},
+        {geodata2, ".*", {git, "https://github.com/brigadier/geodata2.git", "1a4da299683691d6de19b9f261f53b5ea6e10407"}},
+        {hackney, ".*", {git, "https://github.com/benoitc/hackney.git", {tag, "1.6.1"}}},
+        {jsx, ".*", {git, "https://github.com/talentdeficit/jsx.git", {tag, "2.8.0"}}}
+    ]}
+]}].

--- a/docker/prod/s6/zotonic/run
+++ b/docker/prod/s6/zotonic/run
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+export HOME=/opt/ginger
+export ZOTONIC_PIDFILE=/run/zotonic.pid
+
+touch /run/zotonic.pid && chown zotonic /run/zotonic.pid
+
+exec s6-setuidgid zotonic /opt/zotonic/bin/zotonic start-nodaemon


### PR DESCRIPTION
So we get automatically tagged Docker builds when Ginger itself is
tagged.

This replaces https://github.com/driebit/docker-ginger