### PR TITLE
[base] Fix condition for showing rsvp button

### DIFF
--- a/modules/mod_ginger_base/templates/page-actions/page-action-rsvp.tpl
+++ b/modules/mod_ginger_base/templates/page-actions/page-action-rsvp.tpl
@@ -1,5 +1,5 @@
 
-{% if id.action_rsvp|to_integer|is_defined and id.date_end|eq_day:now %}
+{% if id.action_rsvp|to_integer|is_defined and not id.date_end|in_past %}
     {% with btn_class|default:"page-action--rsvp" as btn_class %}
     {% with id.rsvp_max_participants|to_integer as max_participants %}
     {% with id.s.participant|make_list|length|to_integer as participants %}


### PR DESCRIPTION
The current condition for showing the RSVP button on an event's page leads to it only being visible on the last day of the event. This version seems to correct the logic: If the event is not finished yet, you can still add/change your RSVP.