### PR TITLE
[rdf] Implement autoclose in find RDF dialog for UX consistency

### DIFF
--- a/modules/mod_ginger_rdf/mod_ginger_rdf.erl
+++ b/modules/mod_ginger_rdf/mod_ginger_rdf.erl
@@ -151,7 +151,12 @@ event(#postback{message = {admin_connect_select, Args}}, Context) ->
                            _ ->
                                Context
                        end,
-            z_render:dialog_close(Context1);
+            case z_convert:to_bool(proplists:get_value(autoclose, Args)) of
+                true ->
+                    z_render:dialog_close(Context1);
+                false ->
+                    Context1
+            end;
         {error, _} ->
             z_render:growl_error(?__("Insufficient rights to update RDF resources", Context), Context)
     end.

--- a/modules/mod_ginger_rdf/templates/_media_upload_panel_rdf.tpl
+++ b/modules/mod_ginger_rdf/templates/_media_upload_panel_rdf.tpl
@@ -15,6 +15,13 @@
                 data-feedback="trigger: 'dialog-connect-find-linked-data', delegate: 'mod_ginger_rdf', template: '_action_dialog_connect_tab_find_linked_data_results.tpl'">
             </div>
 
+            <div class="modal-footer">
+                <a class="btn btn-default" id="{{ #close }}">
+                    {% if autoclose %}{_ Cancel _}{% else %}{_ Ok _}{% endif %}
+                </a>
+                {% wire id=#close action={dialog_close} %}
+            </div>
+
         </form>
 
     </div>
@@ -34,6 +41,7 @@
         }
     %}
     {% javascript %}
+        $('#dialog-connect-find-linked-data').submit(function() { return false; });
         $('#dialog-connect-find-linked-data').change();
         $("#dialog-connect-found-linked-data").on('click', '.thumbnail', function(e) {
             e.preventDefault();
@@ -42,6 +50,8 @@
                 object: $(this).data('id'),
                 object_title: $(this).data('title')
             });
+            $(this).effect("highlight").toggleClass("thumbnail-connected");
+            $('#{{ #close }}').removeClass("btn-default").addClass("btn-primary");
         });
     {% endjavascript %}
 {% endif %}


### PR DESCRIPTION
* By default, don't close modal after a resource has been added.
* This yields the same UX as we already had for adding internal media.
* Make 'OK' button primary after changes in the modal so it's clear for
  users what their next step is.