### PR TITLE
[foundation] Pin google maps version to v3.31 as v3.32 is troublesome

### DIFF
--- a/modules/mod_ginger_foundation/templates/_script.tpl
+++ b/modules/mod_ginger_foundation/templates/_script.tpl
@@ -30,7 +30,7 @@
 %}
 
 {% if m.modules.active.mod_geo %}
-    <script src="//maps.googleapis.com/maps/api/js?key={{ m.config.mod_geo.api_key.value|escape }}&amp;libraries=places&amp;language=nl&amp;v=3"></script>
+    <script src="//maps.googleapis.com/maps/api/js?key={{ m.config.mod_geo.api_key.value|escape }}&amp;libraries=places&amp;language=nl&amp;v=3.31"></script>
     {% lib
         "js/vendors/infobox_packed.js"
         "js/vendors/markerclusterer.js"


### PR DESCRIPTION
If left as is at v3 it will try to use v3.32 resulting in the following error:
```
js?key=…&language=nl&v=3:40 Uncaught TypeError: Cannot read property 'removeChild' of null
    at MarkerLabel_.onRemove (scripts.min~49189727.js:1936)
    at qu.ug (overlay.js:4)
    at su (overlay.js:1)
    at Object.xk (overlay.js:5)
    at js?key=…language=nl&v=3:146
    at Object._.S (js?key=…&language=nl&v=3:62)
    at MarkerLabel_._.ag.map_changed (js?key=…language=nl&v=3:146)
    at Lc (js?key=…&language=nl&v=3:51)
    at MarkerLabel_._.m.set (js?key=…language=nl&v=3:120)
    at MarkerLabel_.setMap (js?key=…&language=nl&v=3:54)
```

Also see https://github.com/googlemaps/v3-utility-library/issues/393