### PR TITLE
[rdf] Remove duplicate DOM id

### DIFF
--- a/modules/mod_ginger_rdf/templates/_action_dialog_connect_tab_find_linked_data_results.tpl
+++ b/modules/mod_ginger_rdf/templates/_action_dialog_connect_tab_find_linked_data_results.tpl
@@ -1,4 +1,4 @@
-<div id="dialog_connect_results" class="connect-results">
+<div class="connect-results">
 
     {% with m.search[{rdf pagelen=10 id=subject_id text=text|default:"" filters=filters}] as result %}
 


### PR DESCRIPTION
This id was duplicated when multiple results lists are shown in the
'add edges' dialog. The id isn't used anyway, so just remove it.