### PR TITLE
[rdf] Add schema.org RDF serialization

### DIFF
--- a/modules/mod_ginger_base/models/m_ginger_rsc.erl
+++ b/modules/mod_ginger_base/models/m_ginger_rsc.erl
@@ -1,0 +1,15 @@
+-module(m_ginger_rsc).
+
+-export([
+    translations/2
+]).
+
+-type language() :: atom().
+-type translations() :: [{language(), binary()}].
+
+%% @doc Get resource translations.
+-spec translations(atom() | {trans, proplists:proplist()}, z:context()) -> translations().
+translations({trans, Translations}, _Context) ->
+    [{Key, z_html:unescape(Value)} || {Key, Value} <- Translations];
+translations(Value, Context) ->
+    [{z_trans:default_language(Context), Value}].

--- a/modules/mod_ginger_rdf/include/rdf.hrl
+++ b/modules/mod_ginger_rdf/include/rdf.hrl
@@ -27,8 +27,8 @@
 }).
 
 -record(rdf_resource, {
-    id :: binary(),
-    triples = [] :: [#triple{}]
+    id :: ginger_uri:uri(),
+    triples = [] :: [m_rdf:triple()]
 }).
 
 -record(rdf_search, {

--- a/modules/mod_ginger_rdf/models/m_rdf.erl
+++ b/modules/mod_ginger_rdf/models/m_rdf.erl
@@ -20,14 +20,18 @@
     ensure_resource/3,
     ensure_resource_edges/4,
     lookup_triple/2,
-    to_triples/2
+    to_triples/2,
+    rdf_resource/2
 ]).
 
 -opaque rdf_resource() :: #rdf_resource{}.
 -opaque triple() :: #triple{}.
+-type predicate() :: ginger_uri:uri().
+
 -export_type([
     rdf_resource/0,
-    triple/0
+    triple/0,
+    predicate/0
 ]).
 
 m_find_value(#rdf_resource{} = Rdf, #m{value = undefined} = M, _Context) ->
@@ -178,72 +182,7 @@ rsc(Uri, Context) ->
 %% @doc Export resource to a set of triples
 -spec to_triples(integer(), #context{}) -> #rdf_resource{}.
 to_triples(Id, Context) ->
-    Props = case m_rsc:get_visible(Id, Context) of
-		undefined -> [];
-		VisibleProps -> VisibleProps
-	end,
-
-    Triples = lists:flatten(
-        %% Resource properties
-        lists:filtermap(
-            fun(Prop) ->
-                case property_to_triples(Prop, Props, Context) of
-                    [] ->
-                        false;
-                    PropTriples ->
-                        {true, PropTriples}
-                end
-            end,
-            Props
-        ) ++
-
-        %% Site title is publisher
-        publisher_triples(Context) ++
-
-        %% Outgoing resource edges
-        lists:filtermap(
-            fun({Key, Edges}) ->
-                Predicate = m_predicate:get(Key, Context),
-                case proplists:get_value(uri, Predicate) of
-                    undefined ->
-                        false;
-                    PredicateUri ->
-                        {true, lists:filtermap(
-                            fun(Edge) ->
-                                Subject = proplists:get_value(subject_id, Edge),
-                                Object = proplists:get_value(object_id, Edge),
-
-                                {true, [
-                                    #triple{
-                                        type = resource,
-                                        predicate = PredicateUri,
-                                        subject = m_rsc:p(Subject, uri, Context),
-                                        object = m_rsc:p(Object, uri, Context)
-                                    },
-
-                                    %% Add literal triple with the edge's object
-                                    %% title for convenience.
-                                    #triple{
-                                        predicate = <<?NS_DCTERMS, "title">>,
-                                        subject = m_rsc:p(Object, uri, Context),
-                                        object = #rdf_value{value = z_trans:trans(m_rsc:p(Object, title, Context), Context)}
-                                    }
-                                ]}
-                            end,
-                            Edges
-                        )}
-                end
-            end,
-            m_edge:get_edges(Id, Context)
-        )
-    ),
-
-    %% Find thumbnail
-    WithThumbnail =
-        with_original_media(Id, with_thumbnail(Id, Triples, Context), Context),
-
-    Result = z_notifier:foldr(#rsc_to_rdf{id = Id}, WithThumbnail, Context),
-    rdf_resource(m_rsc:p(Id, uri, Context), Result).
+    m_rdf_export:to_rdf(Id, Context).
 
 -spec rdf_resource(binary(), [#triple{}]) -> #rdf_resource{}.
 rdf_resource(SubjectUri, Triples) ->
@@ -251,160 +190,6 @@ rdf_resource(SubjectUri, Triples) ->
         id = SubjectUri,
         triples = [with_subject(SubjectUri, Triple) || Triple <- Triples]
     }.
-
-%% Each property can map to one or more triples
-property_to_triples({_, <<>>}, _Props, _Context) ->
-    %% Skip empty binary values
-    [];
-property_to_triples({_, undefined}, _Props, _Context) ->
-    %% Skip undefined values
-    [];
-property_to_triples({address_city, Value}, _Props, _Context) ->
-    [
-        #triple{predicate = <<?NS_VCARD, "locality">>, object = #rdf_value{value = Value}}
-    ];
-property_to_triples({address_country, Value}, _Props, _Context) ->
-    [
-        #triple{predicate = <<?NS_VCARD, "country-name">>, object = #rdf_value{value = Value}}
-    ];
-property_to_triples({address_postcode, Value}, _Props, _Context) ->
-    [
-        #triple{predicate = <<?NS_VCARD, "postal-code">>, object = #rdf_value{value = Value}}
-    ];
-property_to_triples({address_street_1, Value}, _Props, _Context) ->
-    [
-        #triple{predicate = <<?NS_VCARD, "street-address">>, object = #rdf_value{value = Value}}
-    ];
-property_to_triples({body, Value}, _Props, Context) ->
-    %% TODO add support for multilingual properties
-    [
-        #triple{
-            predicate = <<?NS_DCTERMS, "description">>,
-            object = #rdf_value{value = z_html:strip(z_trans:trans(Value, Context))}
-        }
-    ];
-property_to_triples({category_id, Value}, _Props, Context) ->
-    case get_category_uri(Value, Context) of
-        undefined ->
-            [];
-        Uri ->
-            [
-                #triple{
-                    type = resource,
-                    predicate = <<?NS_RDF, "type">>,
-                    object = Uri
-                }
-            ]
-    end;
-property_to_triples({created, Value}, _Props, _Context) ->
-    [
-        #triple{
-            predicate = <<?NS_DCTERMS, "created">>,
-            object = #rdf_value{value = Value}
-        }
-    ];
-property_to_triples({date_start, Value}, _Props, _Context) ->
-    [
-        #triple{
-            predicate = <<?NS_DCTERMS, "date">>,
-            object = #rdf_value{value = Value}
-        }
-    ];
-property_to_triples({modified, Value}, _Props, _Context) ->
-    [
-        #triple{
-            predicate = <<?NS_DCTERMS, "modified">>,
-            object = #rdf_value{value = Value}
-        }
-    ];
-property_to_triples({name_first, Value}, _Props, _Context) ->
-    [
-        #triple{
-            predicate = <<?NS_FOAF, "firstName">>,
-            object = #rdf_value{value = Value}
-        }
-    ];
-property_to_triples({name_surname, Value}, Props, _Context) ->
-    Surname = case proplists:get_value(name_surname_prefix, Props) of
-        undefined ->
-            Value;
-        <<>> ->
-            Value;
-        Prefix ->
-            iolist_to_binary([Prefix, <<" ">>, Value])
-    end,
-    [
-        #triple{
-            predicate = <<?NS_FOAF, "familyName">>,
-            object = #rdf_value{value = Surname}
-        }
-    ];
-property_to_triples({phone, Value}, _Props, _Context) ->
-    [
-        #triple{
-            predicate = <<?NS_FOAF, "phone">>,
-            object = #rdf_value{value = Value}
-        }
-    ];
-property_to_triples({pivot_location_lat, Value}, _Props, _Context) ->
-    [
-        #triple{
-            predicate = <<?NS_GEO, "lat">>,
-            object = #rdf_value{value = Value}
-        }
-    ];
-property_to_triples({pivot_location_lng, Value}, _Props, _Context) ->
-    [
-        #triple{
-            predicate = <<?NS_GEO, "long">>,
-            object = #rdf_value{value = Value}
-        }
-    ];
-property_to_triples({publication_start, Value}, _Props, _Context) ->
-    [
-        #triple{
-            predicate = <<?NS_DCTERMS, "issued">>,
-            object = #rdf_value{value = Value}
-        }
-    ];
-property_to_triples({license, Value}, _Props, _Context) ->
-    [
-        #triple{
-            type = resource,
-            predicate = <<?NS_DCTERMS, "license">>,
-            object = Value
-        }
-    ];
-property_to_triples({subtitle, Value}, _Props, Context) ->
-    [
-        #triple{
-            predicate = <<?NS_DCTERMS, "alternative">>,
-            object = #rdf_value{value = z_trans:trans(Value, Context)}
-        }
-    ];
-property_to_triples({summary, Value}, _Props, Context) ->
-    [
-        #triple{
-            predicate = <<?NS_DCTERMS, "abstract">>,
-            object = #rdf_value{value = z_trans:trans(Value, Context)}
-        }
-    ];
-property_to_triples({title, Value}, _Props, Context) ->
-    [
-        #triple{
-            predicate = <<?NS_DCTERMS, "title">>,
-            object = #rdf_value{value = z_trans:trans(Value, Context)}
-        }
-    ];
-property_to_triples({website, Value}, _Props, _Context) ->
-    [
-        #triple{
-            predicate = <<?NS_FOAF, "homepage">>,
-            object = Value
-        }
-    ];
-property_to_triples({_Prop, _Val}, _, _) ->
-    [].
 
 %% @doc Return publisher triples based on the site name and hostname
 -spec publisher_triples(#context{}) -> [#triple{}].
@@ -554,46 +339,12 @@ lookup_triples([Predicate | Rest], Triples) ->
 lookup_triples([], _Triples) ->
     undefined.
 
-%% @doc Try to media triples and add them
--spec with_thumbnail(integer(), list(), #context{}) -> list().
-with_thumbnail(Id, Triples, Context) ->
-    maybe_add_media(
-        fun() ->
-            z_media_tag:url(Id, [{mediaclass, <<"foaf-thumbnail">>}, {use_absolute_url, true}], Context)
-        end,
-        <<?NS_FOAF, "thumbnail">>,
-        Triples
-    ).
-
-%% @doc Try to find media triples and add them
--spec with_original_media(integer(), list(), #context{}) -> list().
-with_original_media(Id, Triples, Context) ->
-    maybe_add_media(
-        fun() ->
-            z_media_tag:url(Id, [{use_absolute_url, true}], Context)
-        end,
-        <<?NS_FOAF, "depiction">>,
-        Triples
-    ).
-
 %% @doc Add subject URI to each triple that has none.
 -spec with_subject(binary(), #triple{}) -> #triple{}.
 with_subject(SubjectUri, #triple{subject = undefined} = Triple) ->
     Triple#triple{subject = SubjectUri};
 with_subject(_SubjectUri, #triple{} = Triple) ->
     Triple.
-
-maybe_add_media(Fun, Predicate, Triples) ->
-    case Fun() of
-        {ok, MediaUrl} ->
-            Triples ++ [#triple{
-                type = resource,
-                predicate = Predicate,
-                object = MediaUrl
-            }];
-        {error, _} ->
-            Triples
-    end.
 
 %% @doc Get category URI, starting at the most specific category and falling
 %%      back to parent categories

--- a/modules/mod_ginger_rdf/models/m_rdf_export.erl
+++ b/modules/mod_ginger_rdf/models/m_rdf_export.erl
@@ -1,0 +1,162 @@
+%% @doc Export a Zotonic resource to RDF.
+-module(m_rdf_export).
+
+-export([
+    to_rdf/2,
+    to_rdf/3,
+    translations_to_rdf/3,
+    with_original_media/4,
+    with_thumbnail/4
+]).
+
+-include_lib("zotonic.hrl").
+-include_lib("../include/rdf.hrl").
+
+-spec to_rdf(m_rsc:resource(), z:context()) -> m_rdf:rdf_resource().
+to_rdf(Id, Context) ->
+    to_rdf(Id, [schema_org], Context).
+
+%% @doc Export a Zotonic resource to RDF.
+%%      Combine:
+%%      - properties
+%%      - outgoing edges
+%%      - media.
+-spec to_rdf(m_rsc:resource(), [module()], z:context()) -> m_rdf:rdf_resource().
+to_rdf(Id, Ontologies, Context) ->
+    Properties = m_rsc:get_visible(Id, Context),
+    Edges = m_edge:get_edges(Id, Context),
+    Types = types(proplists:get_value(category_id, Properties), Context),
+    Triples = lists:flatten(
+        Types
+        ++ properties_to_triples(Properties, Ontologies, Context)
+        ++ edges_to_triples(Edges, Ontologies, Context)
+    ),
+    Result = z_notifier:foldr(#rsc_to_rdf{id = Id}, Triples, Context),
+    m_rdf:rdf_resource(m_rsc:p(Id, uri, Context), Result).
+
+properties_to_triples(Properties, Ontologies, Context) ->
+    lists:filtermap(
+        fun(Property) ->
+            case property_to_triples(Property, Properties, Ontologies, Context) of
+                [] ->
+                    false;
+                Triples ->
+                    {true, Triples}
+            end
+        end,
+        Properties
+    ).
+
+property_to_triples({_, <<>>}, _Properties, _Ontologies, _Context) ->
+    [];
+property_to_triples({_, undefined}, _Properties,  _Ontologies, _Context) ->
+    [];
+property_to_triples(Property, Properties, Ontologies, Context) ->
+    [Ontology:property_to_triples(Property, Properties, Context) || Ontology <- Ontologies].
+
+edges_to_triples(Edges, Ontologies, Context) ->
+    lists:filtermap(
+        fun({Predicate, EdgesForPredicate}) ->
+            Uri = m_rsc:p(Predicate, uri, Context),
+            case lists:flatten([
+                Ontology:edge_to_triples(
+                    Predicate,
+                    Uri,
+                    proplists:get_value(subject_id, Edge),
+                    proplists:get_value(object_id, Edge),
+                    Context
+                )
+                || Edge <- EdgesForPredicate, Ontology <- Ontologies
+            ]) of
+                [] ->
+                    false;
+                List ->
+                    {true, List}
+            end
+        end,
+        Edges
+    ).
+
+-spec types(m_rsc:resource(), z:context()) -> [m_rdf:triple()].
+types(Category, Context) ->
+    [
+        #triple{
+            predicate = rdf_property:rdf(<<"type">>),
+            object = get_category_uri(Category, Context)
+        }
+    ].
+
+%% @doc Get category URI, starting at the most specific category and falling
+%%      back to parent categories
+get_category_uri([], _Context) ->
+    undefined;
+get_category_uri([Category | T], Context) ->
+    %% Don't use m_rsc:p(Id, uri, Context) as that will return all URIs, even
+    %% including generated ones (http://site.com/id/123). We only want to return
+    %% a URI if it has been set explicitly.
+    case m_rsc:get_visible(Category, Context) of
+        undefined ->
+            undefined;
+        Props ->
+            case proplists:get_value(uri, Props) of
+                undefined ->
+                    %% Fall back to parent category
+                    get_category_uri(T, Context);
+                Uri ->
+                    Uri
+            end
+    end;
+get_category_uri(Category, Context) ->
+    get_category_uri(lists:reverse(m_category:is_a(Category, Context)), Context).
+
+-spec translations_to_rdf(m_rdf:predicate(), proplists:proplist(), z:context()) -> [m_rdf:triple()].
+translations_to_rdf(Predicate, Translations, Context) ->
+    lists:map(
+        fun({Language, Value}) ->
+            #triple{
+                predicate = Predicate,
+                object = #rdf_value{
+                    language = Language,
+                    value = Value
+                }
+            }
+        end,
+        m_ginger_rsc:translations(Translations, Context)
+    ).
+
+%% @doc Try to find media triples and add them to the set of triples.
+-spec with_original_media(m_rsc:resource(), m_rdf:predicate(), [m_rdf:triple()], z:context())
+    -> [m_rdf:triple()].
+with_original_media(Id, Predicate, Triples, Context) ->
+    maybe_add_media(
+        fun() ->
+            z_media_tag:url(Id, [{use_absolute_url, true}], Context)
+        end,
+        Predicate,
+        Triples
+    ).
+
+%% @doc Try to find media triples and add them.
+-spec with_thumbnail(m_rsc:resource(), m_rdf:predicate(), [m_rdf:triple()], z:context())
+    -> [m_rdf:triple()].
+with_thumbnail(Id, Predicate, Triples, Context) ->
+    maybe_add_media(
+        fun() ->
+            z_media_tag:url(Id, [{mediaclass, <<"rdf-thumbnail">>}, {use_absolute_url, true}], Context)
+        end,
+        Predicate,
+        Triples
+    ).
+
+-spec maybe_add_media(function(), m_rdf:predicate(), [m_rdf:triple()]) -> [m_rdf:triple()].
+maybe_add_media(Fun, Predicate, Triples) ->
+    case Fun() of
+        {ok, MediaUrl} ->
+            Triples ++ [#triple{
+                type = resource,
+                predicate = Predicate,
+                object = MediaUrl
+            }];
+        {error, _} ->
+            Triples
+    end.

--- a/modules/mod_ginger_rdf/support/dcterms.erl
+++ b/modules/mod_ginger_rdf/support/dcterms.erl
@@ -1,0 +1,62 @@
+%% @doc Export Zotonic resources to RDF in Schema.org ontology.
+-module(dcterms).
+
+-export([
+    property_to_triples/3,
+    edge_to_triples/5
+]).
+
+-include_lib("zotonic.hrl").
+-include_lib("../include/rdf.hrl").
+
+-behaviour(rdf_ontology).
+
+property_to_triples({body, Value}, _Props, Context) ->
+    m_rdf_export:translations_to_rdf(rdf_property:dcterms(<<"description">>), Value, Context);
+property_to_triples({created, Value}, _Props, _Context) ->
+    [
+        #triple{
+            predicate = rdf_property:dcterms(<<"created">> ),
+            object = #rdf_value{value = Value}
+        }
+    ];
+property_to_triples({date_start, Value}, _Props, _Context) ->
+    [
+        #triple{
+            predicate = rdf_property:dcterms(<<"date">>),
+            object = #rdf_value{value = Value}
+        }
+    ];
+property_to_triples({modified, Value}, _Props, _Context) ->
+    [
+        #triple{
+            predicate = rdf_property:dcterms(<<"modified">>),
+            object = #rdf_value{value = Value}
+        }
+    ];
+property_to_triples({publication_start, Value}, _Props, _Context) ->
+    [
+        #triple{
+            predicate = rdf_property:dcterms(<<"issued">>),
+            object = #rdf_value{value = Value}
+        }
+    ];
+property_to_triples({license, Value}, _Props, _Context) ->
+    [
+        #triple{
+            type = resource,
+            predicate = rdf_property:dcterms(<<"license">>),
+            object = Value
+        }
+    ];
+property_to_triples({subtitle, Value}, _Props, Context) ->
+    m_rdf_export:translations_to_rdf(rdf_property:dcterms(<<"alternative">>), Value, Context);
+property_to_triples({summary, Value}, _Props, Context) ->
+    m_rdf_export:translations_to_rdf(rdf_property:dcterms(<<"abstract">>), Value, Context);
+property_to_triples({title, Value}, _Props, Context) ->
+    m_rdf_export:translations_to_rdf(rdf_property:dcterms(<<"title">>), Value, Context);
+property_to_triples({_Prop, _Val}, _, _) ->
+    [].
+
+edge_to_triples(_Edge, _Uri, _Subject, _Object, _Context) ->
+    [].

--- a/modules/mod_ginger_rdf/support/rdf_ontology.erl
+++ b/modules/mod_ginger_rdf/support/rdf_ontology.erl
@@ -1,0 +1,23 @@
+%% @doc Behaviour for exporting to RDF ontologies.
+-module(rdf_ontology).
+
+-type edge() :: atom().
+-type property() :: atom().
+-type value() :: any().
+
+-export_type([
+    edge/0,
+    property/0,
+    value/0
+]).
+
+-callback property_to_triples({property(), value()}, proplists:proplist(), z:context()) -> [m_rdf:triple()].
+
+-callback edge_to_triples(
+    edge(),
+    ginger_uri:uri(),
+    m_rsc:resource(),
+    m_rsc:resource(),
+    z:context()
+) -> [m_rdf:triple()].
+

--- a/modules/mod_ginger_rdf/support/rdf_property.erl
+++ b/modules/mod_ginger_rdf/support/rdf_property.erl
@@ -3,6 +3,7 @@
 
 -export([
     'dbpedia-owl'/1,
+    dcterms/1,
     foaf/1,
     geo/1,
     rdf/1,
@@ -17,6 +18,10 @@
 -spec 'dbpedia-owl'(binary()) -> ginger_uri:uri().
 'dbpedia-owl'(Property) ->
     property(?NS_DBPEDIA_OWL, Property).
+
+-spec dcterms(binary()) -> ginger_uri:uri().
+dcterms(Property) ->
+    property(?NS_DCTERMS, Property).
 
 -spec foaf(binary()) -> ginger_uri:uri().
 foaf(Property) ->

--- a/modules/mod_ginger_rdf/support/schema_org.erl
+++ b/modules/mod_ginger_rdf/support/schema_org.erl
@@ -1,0 +1,254 @@
+%% @doc Export Zotonic resources to RDF in Schema.org ontology.
+-module(schema_org).
+
+-export([
+    property_to_triples/3,
+    edge_to_triples/5
+]).
+
+-include_lib("zotonic.hrl").
+-include_lib("../include/rdf.hrl").
+
+-behaviour(rdf_ontology).
+
+property_to_triples({address_country, _}, Properties, _Context) ->
+    [
+        #triple{
+            predicate = rdf_property:schema(<<"location">>),
+            object = #rdf_resource{triples = place_to_triples(Properties)}
+        }
+    ];
+property_to_triples({birth_city, Value}, _Properties, Context) ->
+    [
+        #triple{
+            predicate = rdf_property:schema(<<"birthPlace">>),
+            object = #rdf_value{value = z_html:strip(z_trans:trans(Value, Context))}
+        }
+    ];
+property_to_triples({body, Value}, _Properties, Context) ->
+    m_rdf_export:translations_to_rdf(rdf_property:schema(<<"description">>), Value, Context);
+property_to_triples({created, Value}, _Properties, _Context) ->
+    [
+        #triple{
+            predicate = rdf_property:schema(<<"dateCreated">>),
+            object = #rdf_value{value = Value}
+        }
+    ];
+property_to_triples({date_start, Value}, _Properties, _Context) ->
+    [
+        #triple{
+            predicate = rdf_property:schema(<<"startDate">>),
+            object = #rdf_value{value = Value}
+        }
+    ];
+property_to_triples({date_end, Value}, _Properties, _Context) ->
+    [
+        #triple{
+            predicate = rdf_property:schema(<<"endDate">>),
+            object = #rdf_value{value = Value}
+        }
+    ];
+property_to_triples({license, Value}, _Properties, _Context) ->
+    [
+        #triple{
+            type = resource,
+            predicate = rdf_property:schema(<<"license">>),
+            object = Value
+        }
+    ];
+property_to_triples({modified, Value}, _Properties, _Context) ->
+    [
+        #triple{
+            predicate = rdf_property:schema(<<"dateModified">>),
+            object = #rdf_value{value = Value}
+        }
+    ];
+property_to_triples({name_first, Value}, _Properties, _Context) ->
+    [
+        #triple{
+            predicate = rdf_property:schema(<<"givenName">>),
+            object = #rdf_value{value = Value}
+        }
+    ];
+property_to_triples({name_surname, _}, Properties, _Context) ->
+    Surname = ginger_person:personal_name(
+        Properties,
+        [name_surname_prefix, name_surname]
+    ),
+    [
+        #triple{
+            predicate = rdf_property:schema(<<"familyName">>),
+            object = #rdf_value{value = Surname}
+        }
+    ];
+property_to_triples({phone, Value}, _Properties, _Context) ->
+    [
+        #triple{
+            predicate = rdf_property:schema(<<"telephone">>),
+            object = #rdf_value{value = Value}
+        }
+    ];
+property_to_triples({publication_start, Value}, _Properties, _Context) ->
+    [
+        #triple{
+            predicate = rdf_property:schema(<<"datePublished">>),
+            object = #rdf_value{value = Value}
+        }
+    ];
+property_to_triples({subtitle, Value}, _Properties, Context) ->
+    m_rdf_export:translations_to_rdf(rdf_property:schema(<<"alternateName">>), Value, Context);
+property_to_triples({title, Value}, _Properties, Context) ->
+    m_rdf_export:translations_to_rdf(rdf_property:schema(<<"name">>), Value, Context);
+property_to_triples({website, Value}, _Properties, _Context) ->
+    [
+        #triple{
+            predicate = rdf_property:schema(<<"url">>),
+            object = Value
+        }
+    ];
+property_to_triples(_Property, _Properties, _Context) ->
+    [].
+
+edge_to_triples(_Edge, <<"http://schema.org/", _/binary>> = Uri, Subject, Object, Context) ->
+    %% Return all edges with schema.org predicate URIs.
+    with_title(
+        [
+            #triple{
+                type = resource,
+                predicate = Uri,
+                subject = m_rsc:p(Subject, uri, Context),
+                object = m_rsc:p(Object, uri, Context)
+            }
+        ],
+        Object,
+        Context
+    );
+edge_to_triples(_Edge, <<?NS_FOAF, "depiction">>, Subject, Object, Context) ->
+    case m_rsc:p(Object, license, Context) of
+        undefined ->
+            %% Media is not licensed, so do not export.
+            [];
+        _License ->
+            [
+                #triple{
+                    type = resource,
+                    predicate = rdf_property:schema(<<"image">>),
+                    subject = m_rsc:p(Subject, uri, Context),
+                    object = image_object(Object, Context)
+                }
+            ]
+    end;
+
+edge_to_triples(_Edge, _Uri, _Subject, _Object, _Context) ->
+    %% Ignore all other edges.
+    [].
+
+-spec place_to_triples(proplists:proplist()) -> [m_rdf:triple()].
+place_to_triples(Properties) ->
+    Latitude = proplists:get_value(pivot_location_lat, Properties),
+    Longitude = proplists:get_value(pivot_location_lng, Properties),
+    [
+        #triple{
+            predicate = rdf_property:rdf(<<"type">>),
+            object = rdf_property:schema(<<"Place">>)
+        }
+    ] ++ address_to_triples(Properties) ++ geo_to_triples(Latitude, Longitude).
+
+-spec address_to_triples(proplists:proplist()) -> [m_rdf:triple()].
+address_to_triples(Properties) ->
+    [
+        #triple{
+            predicate = rdf_property:schema(<<"address">>),
+            object = #rdf_resource{triples = [
+                #triple{
+                    predicate = rdf_property:rdf(<<"type">>),
+                    object = rdf_property:schema(<<"PostalAddress">>)
+                },
+                #triple{
+                    predicate = rdf_property:schema(<<"addressLocality">>),
+                    object = #rdf_value{value = proplists:get_value(address_city, Properties)}
+                },
+                #triple{
+                    predicate = rdf_property:schema(<<"postalCode">>),
+                    object = #rdf_value{value = proplists:get_value(address_postcode, Properties)}
+                }
+                #triple{
+                    predicate = rdf_property:schema(<<"streetAddress">>),
+                    object = #rdf_value{value = proplists:get_value(address_street_1, Properties)}
+                },
+                #triple{
+                    predicate = rdf_property:schema(<<"addressCountry">>),
+                    object = #rdf_value{value = proplists:get_value(address_country, Properties)}
+                }
+            ]}
+        }
+    ].
+
+-spec geo_to_triples(float() | undefined, float() | undefined) -> [m_rdf:triple()].
+geo_to_triples(Latitude, Longitude) when Latitude =/= undefined, Longitude =/= undefined ->
+    [
+        #triple{
+            predicate = rdf_property:schema(<<"geo">>),
+            object = #rdf_resource{triples = [
+                #triple{
+                    predicate = rdf_property:rdf(<<"type">>),
+                    object = rdf_property:schema(<<"GeoCoordinates">>)
+                },
+                #triple{
+                    predicate = rdf_property:schema(<<"latitude">>),
+                    object = #rdf_value{value = Latitude}
+                },
+                #triple{
+                    predicate = rdf_property:schema(<<"longitude">>),
+                    object = #rdf_value{value = Longitude}
+                }
+            ]}
+        }
+    ];
+geo_to_triples(_, _) ->
+    [].
+
+%% @doc Add literal triple with the edge's object title for convenience.
+-spec with_title([m_rdf:triple()], m_rsc:resource(), z:context()) -> [m_rdf:triple()].
+with_title(Triples, Object, Context) ->
+    case m_rsc:p(Object, title, <<>>, Context) of
+        <<>> ->
+            Triples;
+        Title ->
+            Triples ++ [
+                #triple{
+                    predicate = rdf_property:schema(<<"title">>),
+                    subject = m_rsc:p(Object, uri, Context),
+                    object = #rdf_value{value = z_trans:trans(Title, Context)}
+                }
+            ]
+    end.
+
+image_object(Id, Context) ->
+    Triples = [
+        #triple{
+            predicate = rdf_property:rdf(<<"type">>),
+            object = rdf_property:schema(<<"ImageObject">>)
+        },
+        #triple{
+            predicate = rdf_property:schema(<<"license">>),
+            object = m_rsc:p(Id, license, Context)
+        }
+    ]
+    ++ m_rdf_export:translations_to_rdf(
+        rdf_property:schema(<<"name">>), m_rsc:p(Id, title, Context),
+        Context
+    ),
+    WithMedia = m_rdf_export:with_original_media(
+        Id,
+        rdf_property:schema(<<"contentUrl">>),
+        Triples,
+        Context
+    ),
+    WithThumbnail = m_rdf_export:with_thumbnail(
+        Id,
+        rdf_property:schema(<<"thumbnail">>),
+        WithMedia,
+        Context
+    ),
+    #rdf_resource{triples = WithThumbnail}.

--- a/modules/mod_ginger_rdf/templates/mediaclass.config
+++ b/modules/mod_ginger_rdf/templates/mediaclass.config
@@ -1,5 +1,5 @@
 [
-    {"foaf-thumbnail", [
+    {"rdf-thumbnail", [
         {width, 100},
         {height, 100}
     ]}


### PR DESCRIPTION
* Move RDF export logic into new m_rdf_export module.
* Add rdf_ontology behaviour and schema_org as the first implementation.
* Export content in all available languages instead of only the default one.
* Add more tests.