### PR TITLE
[base] Check if custom property exists on resource

### DIFF
--- a/modules/mod_ginger_base/controllers/controller_rest.erl
+++ b/modules/mod_ginger_base/controllers/controller_rest.erl
@@ -152,11 +152,17 @@ custom_props(Id, Context) ->
         undefined ->
             null;
         CustomProps ->
-            maps:map(
-               fun (PropName, TypeModule) ->
-                       TypeModule:encode(m_rsc:p(Id, PropName, Context))
-               end,
-               CustomProps
+            maps:fold(
+              fun(PropName, TypeModule, Acc) ->
+                      case m_rsc:p(Id, PropName, Context) of
+                          undefined ->
+                              Acc;
+                          Value ->
+                              Acc#{PropName => TypeModule:encode(Value)}
+                      end
+              end,
+              #{},
+              CustomProps
             )
     end.
 


### PR DESCRIPTION
Check if custom property exists before encoding and adding it to the resources.