### PR TITLE
Convert path ids to integers

### DIFF
--- a/modules/mod_ginger_base/controllers/controller_rest.erl
+++ b/modules/mod_ginger_base/controllers/controller_rest.erl
@@ -202,9 +202,9 @@ path_to_id("/", Context) ->
 path_to_id(Path, Context) ->
     case string:tokens(Path, "/") of
         ["page", Id | _] ->
-            {ok, Id};
+            {ok, erlang:list_to_integer(Id)};
         [_Language, "page", Id | _] ->
-            {ok, Id};
+            {ok, erlang:list_to_integer(Id)};
         _ ->
             case m_rsc:page_path_to_id(Path, Context) of
                 {redirect, Id} ->


### PR DESCRIPTION
Patternmatching the `id` from the path will return a string, we want an integer.