### PR TITLE
[base] Accept empty values as input to filter_https

### DIFF
--- a/modules/mod_ginger_base/filters/filter_https.erl
+++ b/modules/mod_ginger_base/filters/filter_https.erl
@@ -5,6 +5,8 @@
 
 -include("zotonic.hrl").
 
--spec https(ginger_uri:uri(), z:context()) -> ginger_uri:uri().
+-spec https(ginger_uri:uri() | undefined, z:context()) -> ginger_uri:uri().
+https(undefined, _Context) ->
+    undefined;
 https(Uri, _Context) ->
     ginger_uri:https(Uri).


### PR DESCRIPTION
So don't crash when |https is called on an empty value in templates.