### PR TITLE
[docker] Disable heart monitoring in dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,7 @@ services:
             - 443:8443
         environment:
             MAKE: "true"
+            HEART_DISABLE: "true"
             LOGSTASH_HOST: "localhost"
             LOGSTASH_PORT: 5514
         networks:


### PR DESCRIPTION
This fixes an issue when running Zotonic in Docker, where the
Zotonic process was killed by heart with a "heart-beat time-out"
message after the host computer had been stand-by for some time.