### PR TITLE
[base] Fix edge order in REST API

### DIFF
--- a/modules/mod_ginger_base/controllers/controller_rest.erl
+++ b/modules/mod_ginger_base/controllers/controller_rest.erl
@@ -116,7 +116,7 @@ edges(RscId, Context) ->
                   predicate_name => Key,
                   resource => rsc(proplists:get_value(object_id, Rsc), Context, false)
                  }
-                || Rsc <- Rscs
+                || Rsc <- lists:reverse(Rscs)
               ]
       end,
       m_edge:get_edges(RscId, Context)).


### PR DESCRIPTION
Keep the edges in order they are given in the admin.