### PR TITLE
Bump Elasticsearch version in Docker Compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
 
     elasticsearch:
-        image: elasticsearch:5.1-alpine
+        image: elasticsearch:5.3.2-alpine
         ports:
             - 9200:9200
         volumes:


### PR DESCRIPTION
The previous elasticsearch version crashes almost immediatly on my system.
I don't know the exact cause, but a (small) version bump fixed the issue.
Because we use ES v5.3.2 in our production environments too I picked that
version to use here.