### PR TITLE
[embed] Fix duplicate key html_elt_extra

### DIFF
--- a/modules/mod_ginger_embed/mod_ginger_embed.erl
+++ b/modules/mod_ginger_embed/mod_ginger_embed.erl
@@ -21,8 +21,6 @@
 -include("zotonic.hrl").
 
 manage_schema(_Version, Context) ->
-    m_config:set_value(site, html_elt_extra, <<"embed,iframe,object,script,ginger-embed">>, Context),
-    m_config:set_value(site, html_attr_extra, <<"data,allowfullscreen,flashvars,frameborder,scrolling,async,defer,data-rdf">>, Context),
     Datamodel = #datamodel{
         categories=[
             {ginger_embed, media, [


### PR DESCRIPTION
This fixes: duplicate key value violates unique constraint
\"config_module_key_key\"">>,[{detail,
<<"Key (module, key)=(site, html_elt_extra) already exists.">>}]

This is already configured in mod_ginger_base, so no need to duplicate
it here.