### PR TITLE
[remark] Fix media upload by passing remark_id as subject_id

### DIFF
--- a/modules/mod_ginger_edit/templates/_editor.tpl
+++ b/modules/mod_ginger_edit/templates/_editor.tpl
@@ -13,7 +13,8 @@ overrides_tpl: (optional) template location that contains JavaScript overrides f
         subject_id=id
         predicate=`depiction`
         is_zmedia
-        tab="depiction"
+        tab=media_tab|default:"depiction"
+        tabs_enabled=media_tabs_enabled
         callback="window.zAdminMediaDone"
         center=0
         autoclose

--- a/modules/mod_ginger_remark/templates/remark/remark-edit.tpl
+++ b/modules/mod_ginger_remark/templates/remark/remark-edit.tpl
@@ -40,40 +40,13 @@
 
     {% wire id="rscform" type="submit" postback={rscform on_success={script script="$(document).trigger('remark:saved', " ++ the_remark_id ++ ");" }} delegate="mod_ginger_edit" %}
 
-    {% wire name="zmedia"
-    action={
-        dialog_open
-        template="_action_dialog_connect.tpl"
-        title=_"Insert image"
-        subject_id=the_remark_id
-        predicate=`depiction`
-        tab="upload"
-        tabs_enabled=["upload","oembed"]
-        callback="window.zAdminMediaDone"
-        center=0
-    }
-    %}
-
-    {% wire name="zlink"
-    action={
-        dialog_open
-        template="_action_dialog_connect.tpl"
-        title=_"Add link"
-        subject_id=the_remark_id
-        is_zlink
-        tab="find"
-        callback="window.zAdminLinkDone"
-        center=0
-    } %}
-
     {% javascript %}
-        z_editor.init();
         $(document).trigger('remark:editing', {{ the_remark_id }});
         {% if is_new == 1 %}
             $(document).trigger('remark:new', {{ the_remark_id }});
         {% endif %}
     {% endjavascript %}
 
+    {% include "_editor.tpl" overrides_tpl="_tinymce_overrides.tpl" media_tab="upload" media_tabs_enabled=["upload", "oembed"] id=the_remark_id %}
 {% endwith %}
 
-{% include "_editor.tpl" overrides_tpl="_tinymce_overrides.tpl" %}


### PR DESCRIPTION
This was broken in #267, where subject_id was defaulted to id instead of
the_remark_id, because the zmedia and zlink wires in remark-edit.tpl were
overridden by those in _editor.tpl.