### PR TITLE
[rdf] Add dependency to mod_content_groups

### DIFF
--- a/modules/mod_ginger_rdf/mod_ginger_rdf.erl
+++ b/modules/mod_ginger_rdf/mod_ginger_rdf.erl
@@ -8,6 +8,7 @@
 -mod_description("RDF in Zotonic").
 -mod_prio(400).
 -mod_schema(4).
+-mod_depends([mod_content_groups]).
 
 -behaviour(gen_server).
 


### PR DESCRIPTION
This is necessary because mod_ginger_rdf:manage_schema/2 creates a
subcategory of content_groups, which must therefore be created first.