### PR TITLE
[base] Fix REST API blocks output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
     - docker version
     - docker-compose version
     - docker-compose run --rm zotonic make
-    - docker-compose run zotonic bin/zotonic runtests mod_ginger_activity mod_ginger_collection mod_ginger_rdf
+    - docker-compose run zotonic bin/zotonic runtests m_ginger_rest_tests mod_ginger_activity mod_ginger_collection mod_ginger_rdf
 
 notifications:
     slack:

--- a/modules/mod_ginger_base/tests/m_ginger_rest_tests.erl
+++ b/modules/mod_ginger_base/tests/m_ginger_rest_tests.erl
@@ -1,0 +1,54 @@
+-module(m_ginger_rest_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+-include_lib("zotonic.hrl").
+
+rsc_blocks_test() ->
+    {ok, Id} = m_rsc:insert(
+        [
+            {category, text},
+            {blocks, [
+                [
+                    {type, <<"header">>},
+                    {name, <<"translated_header">>},
+                    {header, {trans, [
+                        {nl, <<"Vertaalde header">>},
+                        {en, <<"Translated header">>}
+                    ]}},
+                    {body, <<"Untranslated body">>}
+                ],
+
+                [
+                    {type, <<"page">>},
+                    {name, <<"page2">>},
+                    {style, <<"quote">>},
+                    {rsc_id, 19013}
+                ]
+            ]}
+        ],
+        context()
+    ),
+    #{<<"blocks">> := [Block1, Block2]} = Rest = m_ginger_rest:rsc(Id, context()),
+    ?assertEqual(
+        [
+            {nl, <<"Vertaalde header">>},
+            {en, <<"Translated header">>}
+        ],
+        maps:get(<<"header">>, Block1)
+    ),
+    ?assertEqual(
+        [
+            {en, <<"Untranslated body">>}
+        ],
+        maps:get(<<"body">>, Block1)
+    ),
+
+    ?assertEqual(<<"page">>, maps:get(<<"type">>, Block2)),
+    ?assertEqual(<<"page2">>, maps:get(<<"name">>, Block2)),
+    ?assertEqual(<<"quote">>, maps:get(<<"style">>, Block2)),
+    ?assertEqual(19013, maps:get(<<"rsc_id">>, Block2)),
+
+    jsx:encode(Rest).
+
+context() ->
+    z_acl:sudo(z_context:new(testsandboxdb)).


### PR DESCRIPTION
This fixes a bug introduced in #473.

* Translated properties were causing jsx:encode to fail.
* Add test.