### PR TITLE
[skel] Don't change mod_schema version

### DIFF
--- a/skel/SITE.erl
+++ b/skel/SITE.erl
@@ -5,6 +5,8 @@
 -mod_description("").
 -mod_prio(10).
 -mod_depends([mod_ginger_base]).
+
+%% Don't change this, but rely on schema:reset/1 instead.
 -mod_schema(1).
 
 -include_lib("zotonic.hrl").
@@ -13,5 +15,5 @@
     manage_schema/2
 ]).
 
-manage_schema(_Type, Context) ->
+manage_schema(_Version, Context) ->
     %%site%%_data_fixtures:load(Context).


### PR DESCRIPTION
* Changing the version creates trouble when switching branches (that
  have a lower version), as schema downgrades are not supported.
* It's good practice to have an idempotent schema instead of versions,
  anyway.
* schema:reset/1 always runs when deploying sites (in .gitlab-ci.yml),
  so the only (but significant!) downside of this is the fact that
  developers must remember to run schema:reset/1 locally.