### PR TITLE
Use prefix query for search suggestions

### DIFF
--- a/modules/mod_ginger_base/templates/search-suggestions/search-query.tpl
+++ b/modules/mod_ginger_base/templates/search-suggestions/search-query.tpl
@@ -24,7 +24,7 @@
         unfinished_or_nodate,
         authoritative
 %}
-    {% with m.search[{ginger_search cat=cat cat_exclude=cat_exclude cat_exclude_defaults=cat_exclude_defaults cat_promote=cat_promote cat_promote_recent=cat_promote_recent authoritative=authoritative unfinished_or_nodate=unfinished_or_nodate content_group=content_group text=search_text pagelen=pagelen}] as result %}
+    {% with m.search[{ginger_search cat=cat cat_exclude=cat_exclude cat_exclude_defaults=cat_exclude_defaults cat_promote=cat_promote cat_promote_recent=cat_promote_recent authoritative=authoritative unfinished_or_nodate=unfinished_or_nodate content_group=content_group prefix=search_text pagelen=pagelen}] as result %}
         {% include results_template result=result %}
     {% endwith %}
 


### PR DESCRIPTION
* This way, users get results for partial queries, too.
* Only search in fields that are shown in the suggestion results, i.e.
  title*.
* See https://github.com/driebit/mod_elasticsearch/#extra-query-arguments