### PR TITLE
[rdf] De-duplicate object ids to prevent infinite pivot

### DIFF
--- a/modules/mod_ginger_rdf/models/m_rdf.erl
+++ b/modules/mod_ginger_rdf/models/m_rdf.erl
@@ -178,7 +178,7 @@ ensure_resource_edges(Subject, Predicate, Rdfs, Context) ->
         end,
         Rdfs
     ),
-    ok = m_edge:replace(Subject, Predicate, Ids, Context).
+    ok = m_edge:replace(Subject, Predicate, unique(Ids), Context).
 
 %% @doc Derive Zotonic resource properties from RDF triples.
 -spec rdf_to_rsc_props(#rdf_resource{}) -> proplists:proplist().
@@ -366,3 +366,7 @@ literal_object_value(#rdf_value{value = Value}) ->
     Value;
 literal_object_value(Other) ->
     Other.
+
+-spec unique([any()]) -> [any()].
+unique(Ids) ->
+    sets:to_list(sets:from_list(Ids)).


### PR DESCRIPTION
m_edge:replace/4 with duplicate object ids, e.g. [1, 2, 3, 1] sees
those edges as different from the current edges [1, 2, 3], which
causes an m_rsc:touch/2, thus repivot, of the subject in
m_edge:set_sequence/4.

By de-duplicating the ids, m_edge sees them as identical to the current
ones and skips set_sequence/4.