### PR TITLE
Show 'ratelimit' error.

### DIFF
--- a/modules/mod_ginger_edit/templates/_logon_error.tpl
+++ b/modules/mod_ginger_edit/templates/_logon_error.tpl
@@ -1,6 +1,17 @@
 
 {% if reason == "pw" %}
     <p style="color: red;">{_ You entered an unknown username or password.  Please try again. _}</p>
+{% elseif reason == "ratelimit" %}
+    <p style="color: red;">
+        {_ Too many retries. _}
+        {_ Please try again in _}
+        {% with m.ratelimit.timeout as seconds %}
+            {% if seconds == 3600 %}{_ an hour _}.
+            {% elseif seconds > 3600 %}{{ ((seconds+3599)/3600)|round }} {_ hours _}.
+            {% else %}{{ (seconds / 60)|round }} {_ minutes _}.
+            {% endif %}
+        {% endwith %}
+    </p>
 {% elseif reason == "user_not_enabled" %}
     <p style="color: red;">{_ You have to confirm your account first.  Please see the email send to you. _}</p>
 {% elseif reason == "reminder" %}


### PR DESCRIPTION
The `_logon_error.tpl` is overruled in ginger, so the ratelimit error was not shown.

(Note: the best solution is to overrule less templates...)