### PR TITLE
[doc] Document selective Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ start: up-support
 	@bash -c "trap 'trap - SIGINT SIGTERM ERR; docker-compose stop elasticsearch kibana postgres; exit 0' SIGINT SIGTERM ERR; $(MAKE) start-zotonic"
 
 start-zotonic:
-	../zotonic/bin/zotonic debug
+	cd ${ZOTONIC}; bin/zotonic debug
 
 test:
 # Disconnect and reconnect the Ginger container to refresh the site alias (see docker-compose.yml).

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,7 @@ help:
 	@echo "  prompt                  Open shell prompt at Zotonic container"
 	@echo "  shell                   Open Zotonic shell"
 	@echo "  psql                    Open PostgreSQL interactive terminal"
+	@echo "  start					 Run Zotonic on the host and all other services in containers"
 	@echo "  test site=site-name     Run browser site tests in Docker container (args=Nightwatch arguments url=http://...)"
 	@echo "  test-chrome =site-name  Run browser site tests locally (args=Nightwatch arguments url=http://...)"
 	@echo "  tests                   Find all Ginger tests and run them"
@@ -78,6 +79,13 @@ prompt:
 psql:
 	@docker-compose exec postgres psql -U zotonic
 
+start: up-support
+	echo "rdr pass inet proto tcp from any to any port 80 -> 127.0.0.1 port 8000" | sudo pfctl -ef -; true
+	@bash -c "trap 'trap - SIGINT SIGTERM ERR; docker-compose stop elasticsearch kibana postgres; exit 0' SIGINT SIGTERM ERR; $(MAKE) start-zotonic"
+
+start-zotonic:
+	../zotonic/bin/zotonic debug
+
 test:
 # Disconnect and reconnect the Ginger container to refresh the site alias (see docker-compose.yml).
 	@docker network disconnect ginger_selenium ginger_zotonic_1
@@ -97,7 +105,7 @@ up:
 	@echo "> Started. Open http://localhost in your browser."
 
 up-support:
-	@docker-compose up --build kibana postgres
+	@docker-compose up -d --build kibana postgres
 
 up-zotonic:
 # See https://github.com/zotonic/zotonic/issues/1321

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ help:
 	@echo "  prompt                  Open shell prompt at Zotonic container"
 	@echo "  shell                   Open Zotonic shell"
 	@echo "  psql                    Open PostgreSQL interactive terminal"
-	@echo "  start					 Run Zotonic on the host and all other services in containers"
+	@echo "  start                   Run Zotonic on the host and all other services in containers"
 	@echo "  test site=site-name     Run browser site tests in Docker container (args=Nightwatch arguments url=http://...)"
 	@echo "  test-chrome =site-name  Run browser site tests locally (args=Nightwatch arguments url=http://...)"
 	@echo "  tests                   Find all Ginger tests and run them"

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ psql:
 
 start: up-support
 	echo "rdr pass inet proto tcp from any to any port 80 -> 127.0.0.1 port 8000" | sudo pfctl -ef -; true
-	@bash -c "trap 'trap - SIGINT SIGTERM ERR; docker-compose stop elasticsearch kibana postgres; exit 0' SIGINT SIGTERM ERR; $(MAKE) start-zotonic"
+	@bash -c "trap 'trap - SIGINT SIGTERM 0 ERR; docker-compose stop elasticsearch kibana postgres; exit 0' SIGINT SIGTERM 0 ERR; $(MAKE) start-zotonic"
 
 start-zotonic:
 	cd ${ZOTONIC}; bin/zotonic debug

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,8 @@ include .env
 
 NPM_PATH := ./node_modules/.bin
 export PATH := $(NPM_PATH):$(PATH)
+export JSX_FORCE_MAPS := 1
+export ERLASTIC_SEARCH_JSON_MODULE := jsx
 
 help:
 	@echo "Run: make <target> where <target> is one of the following:"

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ source code, too.
 All other services (PostgreSQL, Elasticsearch, Kibana) still run in
 containers.
 
-First, install Install Erlang locally:
+First, install install Erlang locally:
 
 ```bash
-$ brew install erlang@20
+$ brew install erlang@20 imagemagick
 $ brew link erlang@20 --force
 ```
 
@@ -121,12 +121,18 @@ And run Zotonic:
 
 ```bash
 $ cd ginger
-$ make up-support
-$ cd ../zotonic
-$ bin/zotonic debug
+$ make start
 ```
 
-Zotonic then runs on port 8000: http://localhost:8000.
+You have to enter your account’s sudo password to enable port forwarding 
+(from port 80 to 8000).
+
+First the supporting Docker containers are started, then Zotonic is run.
+Zotonic is then available on http://localhost.
+
+When you quit Zotonic through Ctrl+C, the Docker containers are stopped 
+as 
+well.
 
 Sites overview
 ---------------

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ First, install Install Erlang locally:
 
 ```bash
 $ brew install erlang@20
+$ brew link erlang@20 --force
 ```
 
 Then clone both Ginger and Zotonic:

--- a/README.md
+++ b/README.md
@@ -130,8 +130,7 @@ You have to enter your account’s sudo password to enable port forwarding
 First the supporting Docker containers are started, then Zotonic is run.
 Zotonic is then available on http://localhost.
 
-When you quit Zotonic through Ctrl+C, the Docker containers are stopped 
-as well.
+When you quit Zotonic, the Docker containers are stopped as well.
 
 Sites overview
 ---------------

--- a/README.md
+++ b/README.md
@@ -131,8 +131,7 @@ First the supporting Docker containers are started, then Zotonic is run.
 Zotonic is then available on http://localhost.
 
 When you quit Zotonic through Ctrl+C, the Docker containers are stopped 
-as 
-well.
+as well.
 
 Sites overview
 ---------------

--- a/README.md
+++ b/README.md
@@ -26,7 +26,16 @@ Getting started
 
 Clone this repository and install [Docker](https://www.docker.com/getdocker).
 
-Then open a terminal in the Ginger directory and start the containers:
+You can run Ginger in three ways:
+
+1. all-in Docker (easiest)
+2. [selective Docker](#selective-docker-recommended) (**recommended** because it’s more flexible and has better 
+   performance while being only slightly harder to set up)
+3. don’t use Docker at all (hardest). 
+
+### 1. All-in Docker
+
+To run Ginger completely in Docker containers, open a terminal and enter:
 
 ```bash
 $ make up
@@ -65,6 +74,55 @@ $ make && bin/zotonic runtests mod_ginger_collection
 ```
 
 For more, see the [Docker](docs/docker.md) doc chapter.
+
+### 2. Selective Docker (recommended)
+
+Due to limitations in Docker for Mac, file synchronization performance suffers
+when you have large amounts of files (i.e. many sites with node_modules/ 
+directories).
+
+By running Zotonic directly on your host (outside Docker) we circumvent this
+limitation. Another advantage is that you can directly make changes in Zotonic
+source code, too. 
+
+All other services (PostgreSQL, Elasticsearch, Kibana) still run in
+containers.
+
+First, install Install Erlang locally:
+
+```bash
+$ brew install erlang@20
+```
+
+Then clone both Ginger and Zotonic:
+
+```bash
+$ git clone https://github.com/driebit/ginger.git
+$ git clone https://github.com/zotonic/zotonic.git --branch 0.x 
+```
+
+Copy Ginger’s configuration file, which includes its dependencies:
+
+```bash
+cp ginger/config/zotonic.config ~/.zotonic/0/zotonic.config
+```
+
+Point Zotonic to your Ginger sites/ and modules/ directories:
+
+```bash
+$ mkdir zotonic/user
+$ ln -s ginger/sites zotonic/user/sites
+$ ln -s ginger/modules zotonic/user/modules
+```
+
+And run Zotonic:
+
+```bash
+$ cd zotonic/
+$ bin/zotonic debug
+```
+
+Zotonic then runs on port 8000: http://localhost:8000.
 
 Sites overview
 ---------------

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Clone this repository and install [Docker](https://www.docker.com/getdocker).
 You can run Ginger in three ways:
 
 1. all-in Docker (easiest)
-2. [selective Docker](#selective-docker-recommended) (**recommended** because it’s more flexible and has better 
+2. [selective Docker](#2-selective-docker-recommended) (**recommended** because it’s more flexible and has better 
    performance while being only slightly harder to set up)
 3. don’t use Docker at all (hardest). 
 
@@ -111,14 +111,16 @@ Point Zotonic to your Ginger sites/ and modules/ directories:
 
 ```bash
 $ mkdir zotonic/user
-$ ln -s ginger/sites zotonic/user/sites
-$ ln -s ginger/modules zotonic/user/modules
+$ ln -s ../../ginger/sites zotonic/user/sites
+$ ln -s ../../ginger/modules zotonic/user/modules
 ```
 
 And run Zotonic:
 
 ```bash
-$ cd zotonic/
+$ cd ginger
+$ make up-support
+$ cd ../zotonic
 $ bin/zotonic debug
 ```
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ $ git clone https://github.com/zotonic/zotonic.git --branch 0.x
 Copy Ginger’s configuration file, which includes its dependencies:
 
 ```bash
-cp ginger/config/zotonic.config ~/.zotonic/0/zotonic.config
+$ mkdir -p ~/.zotonic/0
+$ cp ginger/config/zotonic.config ~/.zotonic/0/zotonic.config
 ```
 
 Point Zotonic to your Ginger sites/ and modules/ directories:

--- a/config/zotonic.config
+++ b/config/zotonic.config
@@ -1,0 +1,15 @@
+[{zotonic,
+    [
+        {port, 8000},
+        {password, ""},
+        {deps, [
+            {erlastic_search, ".*", {git, "https://github.com/tsloughter/erlastic_search.git", "8482766d479a0d41b3e7d1e754e096293fa30955"}},
+            {geodata2, ".*", {git, "https://github.com/brigadier/geodata2.git", "1a4da299683691d6de19b9f261f53b5ea6e10407"}},
+            {hackney, ".*", {git, "https://github.com/benoitc/hackney.git", {tag, "1.14.3"}}},
+            {hamcrest, ".*", {git, "https://github.com/truqu/hamcrest-erlang", "e413409e9424751865bd58d65c49fa6659d94d2d"}},
+            {jsx, ".*", {git, "https://github.com/talentdeficit/jsx.git", {tag, "2.8.0"}}},
+            {lager_logstash, "", {git, "https://github.com/rpt/lager_logstash.git", {tag, "0.1.3"}}},
+            {tql, ".*", {git, "https://github.com/driebit/tql", {tag, "1.2.1"}}}
+        ]}
+    ]
+}].

--- a/config/zotonic.config
+++ b/config/zotonic.config
@@ -2,7 +2,6 @@
     [
         {user_sites_dir, "../ginger/sites"},
         {user_modules_dir, "../ginger/modules"},
-        {port, 8000},
         {password, ""},
         {deps, [
             {erlastic_search, ".*", {git, "https://github.com/tsloughter/erlastic_search.git", "8482766d479a0d41b3e7d1e754e096293fa30955"}},

--- a/config/zotonic.config
+++ b/config/zotonic.config
@@ -1,5 +1,7 @@
 [{zotonic,
     [
+        {user_sites_dir, "../ginger/sites"},
+        {user_modules_dir, "../ginger/modules"},
         {port, 8000},
         {password, ""},
         {deps, [


### PR DESCRIPTION
This adds a hybrid Docker setup that is compatible with the full Docker setup. Zotonic itself runs directly on the host, communicating with containers running Postgres and Elasticsearch.