### PR TITLE
Preserve order of triples when converting to json list

### DIFF
--- a/modules/mod_ginger_rdf/support/ginger_json_ld.erl
+++ b/modules/mod_ginger_rdf/support/ginger_json_ld.erl
@@ -345,7 +345,7 @@ merge_values(KeyValue, Acc) ->
         undefined ->
             maps:merge(Acc, KeyValue);
         Value when is_list(Value) ->
-            Acc#{Key => [NewValue | Value]};
+            Acc#{Key => Value ++ [NewValue]};
         Value ->
-            Acc#{Key => [NewValue | [Value]]}
+            Acc#{Key => [Value] ++ [NewValue]}
     end.


### PR DESCRIPTION
Previously when serializing rdf triples into json, triples with
the same predicate were serialized into a list, but in the reverse
order of the triples. This commit makes sure the order is unchanged.