### PR TITLE
[base] Support unique name as argument to REST endpoint

### DIFF
--- a/modules/mod_ginger_base/controllers/controller_rest_resources.erl
+++ b/modules/mod_ginger_base/controllers/controller_rest_resources.erl
@@ -21,7 +21,7 @@
 -record(state, { mode = undefined
                , path_info = undefined
                , context = undefined
-               , document_id = undefined
+               , rsc_id = undefined :: m_rsc:resource()
                }
        ).
 
@@ -39,13 +39,11 @@ service_available(Req, State) ->
     {true, Req, State#state{context = Context}}.
 
 malformed_request(Req, State = #state{mode = document, path_info = id}) ->
-    case string:to_integer(wrq:path_info(id, Req)) of
-        {error, _Reason} ->
+    case wrq:path_info(id, Req) of
+        undefined ->
             {true, Req, State};
-        {Id, []} ->
-            {false, Req, State#state{document_id = Id}};
-        {_Int, _Rest} ->
-            {true, Req, State}
+        Id ->
+            {false, Req, State#state{rsc_id = Id}}
     end;
 malformed_request(Req, State) ->
     {false, Req, State}.
@@ -57,12 +55,12 @@ resource_exists(Req, State = #state{mode = collection}) ->
     {true, Req, State};
 resource_exists(Req, State = #state{mode = document, path_info = id}) ->
     Context = State#state.context,
-    {m_rsc:exists(State#state.document_id, Context), Req, State};
+    {m_rsc:exists(State#state.rsc_id, Context), Req, State};
 resource_exists(Req, State = #state{mode = document, path_info = path}) ->
     Context = State#state.context,
     case path_to_id(wrq:path_info(path, Req), Context) of
         {ok, Id} ->
-            {m_rsc:exists(Id, Context), Req, State#state{document_id = Id}};
+            {m_rsc:exists(Id, Context), Req, State#state{rsc_id = Id}};
         {error, _} ->
             {false, Req, State}
     end.
@@ -71,7 +69,7 @@ content_types_provided(Req, State) ->
     {[{"application/json", to_json}], Req, State}.
 
 delete_resource(Req, State = #state{mode = document}) ->
-    ok = m_rsc:delete(State#state.document_id, State#state.context),
+    ok = m_rsc:delete(State#state.rsc_id, State#state.context),
     {true, Req, State}.
 
 to_json(Req, State = #state{mode = collection}) ->
@@ -90,7 +88,7 @@ to_json(Req, State = #state{mode = collection}) ->
     Json = jsx:encode([rsc(Id, Context, true) || Id <- Ids]),
     {Json, Req, State};
 to_json(Req, State = #state{mode = document}) ->
-    Id = State#state.document_id,
+    Id = State#state.rsc_id,
     Context = State#state.context,
     Json = jsx:encode(rsc(Id, Context, true)),
     {Json, Req, State}.
@@ -225,25 +223,6 @@ malformed_request_test_() ->
                                                  , path_info = path
                                                  }
                                      ),
-                ok
-        end
-      , fun () ->
-                meck:expect(wrq, path_info, 2, "not-an-integer"),
-                {true, _, _} =
-                    malformed_request(req, #state{ mode = document
-                                                 , path_info = id
-                                                 }
-                                     ),
-                ok
-        end
-      , fun () ->
-                meck:expect(wrq, path_info, 2, "23"),
-                {false, _, State} =
-                    malformed_request(req, #state{ mode = document
-                                                 , path_info = id
-                                                 }
-                                     ),
-                23 = State#state.document_id,
                 ok
         end
       ]

--- a/modules/mod_ginger_base/models/m_ginger_rest.erl
+++ b/modules/mod_ginger_base/models/m_ginger_rest.erl
@@ -16,8 +16,8 @@
 -include_lib("stdlib/include/qlc.hrl").
 
 %% @doc Get REST resource properties.
--spec rsc(m_rsc:resource(), z:context()) -> resource_properties().
-rsc(Id, Context) ->
+-spec rsc(m_rsc:resource(), z:context()) -> resource_properties() | undefined.
+rsc(Id, Context) when is_integer(Id) ->
     Rsc = #{ <<"id">> => Id
            , <<"title">> => translations(Id, title, Context)
            , <<"body">> => translations(Id, body, Context)
@@ -28,7 +28,14 @@ rsc(Id, Context) ->
            , <<"properties">> => custom_props(Id, Context)
            , <<"blocks">> => blocks(Id, Context)
            },
-    with_media(Rsc, Context).
+    with_media(Rsc, Context);
+rsc(UniqueName, Context) ->
+    case m_rsc:name_to_id(UniqueName, Context) of
+        {ok, Id} ->
+            rsc(Id, Context);
+        _ ->
+            undefined
+    end.
 
 %% @doc Add all edges to resource.
 -spec with_edges(map(), z:context()) -> map().


### PR DESCRIPTION
This makes lookups for resources with a fixed name easier, e.g.
http://site/data/resources/some_resource instead of
http://site/data/resources/123456.