### PR TITLE
Add support for cat_promote, and return ALL edges of a resource from …

### DIFF
--- a/modules/mod_ginger_base/controllers/controller_rest_resources.erl
+++ b/modules/mod_ginger_base/controllers/controller_rest_resources.erl
@@ -92,7 +92,8 @@ to_json(Req, State = #state{mode = collection}) ->
 to_json(Req, State = #state{mode = document}) ->
     Id = State#state.document_id,
     Context = State#state.context,
-    Json = jsx:encode(rsc(Id, Context, true)),
+    Rsc = m_ginger_rest:rsc(Id, Context),
+    Json = jsx:encode(m_ginger_rest:with_edges(Rsc, Context)),
     {Json, Req, State}.
 
 process_post(Req, State = #state{mode = collection}) ->

--- a/modules/mod_ginger_base/controllers/controller_search.erl
+++ b/modules/mod_ginger_base/controllers/controller_search.erl
@@ -84,6 +84,7 @@ whitelist() ->
     [
         cat,
         cat_exclude,
+        cat_promote,
         cat_promote_recent,
         content_group,
         facet,
@@ -153,7 +154,7 @@ is_visible(Document, _Context) when is_map(Document) ->
 -spec search_result(m_rsc:resource() | map(), z:context()) -> map().
 search_result(Id, Context) when is_integer(Id) ->
     Rsc = m_ginger_rest:rsc(Id, Context),
-    m_ginger_rest:with_edges(Rsc, [depiction], Context);
+    m_ginger_rest:with_edges(Rsc, Context);
 search_result(Document, _Context) when is_map(Document) ->
     %% Return a document (such as an Elasticsearch document) as is.
     Document.


### PR DESCRIPTION
…the search endpoint