### PR TITLE
[base] Handle undefined facets in search results for controller_search

### DIFF
--- a/modules/mod_ginger_base/controllers/controller_search.erl
+++ b/modules/mod_ginger_base/controllers/controller_search.erl
@@ -163,6 +163,8 @@ search_result(Document, _Context) when is_map(Document) ->
 %% @doc Combine separate facets in the search result into one property:
 %% (date_start_min, date_start_max) into (date_start.min, date_start.max).
 -spec facets(list() | map()) -> map().
+facets(undefined) ->
+    [];
 facets([]) ->
     [];
 facets(Facets) ->


### PR DESCRIPTION
If returned search facets for controller_search:to_json are undefined, use empty list