### PR TITLE
[base] Add string contains function

### DIFF
--- a/modules/mod_ginger_base/support/g_string.erl
+++ b/modules/mod_ginger_base/support/g_string.erl
@@ -16,6 +16,8 @@
 
 %% @doc Check if a string contains another string
 -spec contains(list(), list()) -> boolean().
+contains([], []) ->
+    true;
 contains(_, []) ->
     false;
 contains(Pred, Str) ->

--- a/modules/mod_ginger_base/support/g_string.erl
+++ b/modules/mod_ginger_base/support/g_string.erl
@@ -1,0 +1,32 @@
+%%%-------------------------------------------------------------------
+%%% @author driebit <tech@driebit.nl>
+%%% @copyright (C) 2019, driebit
+%%% @doc
+%%% Utility functions for operations on strings
+%%% @end
+%%%-------------------------------------------------------------------
+-module(g_string).
+
+%% API
+-export([contains/2]).
+
+%%%===================================================================
+%%% API
+%%%===================================================================
+
+%% @doc Check if a string contains another string
+-spec contains(list(), list()) -> boolean().
+contains(_, []) ->
+    false;
+contains(Pred, Str) ->
+    case lists:prefix(Pred, Str) of
+        true->
+            true;
+        false ->
+            contains(Pred, lists:nthtail(1, Str))
+    end.
+
+
+%%%===================================================================
+%%% Internal functions
+%%%===================================================================

--- a/modules/mod_ginger_base/tests/mod_ginger_base_g_string_tests.erl
+++ b/modules/mod_ginger_base/tests/mod_ginger_base_g_string_tests.erl
@@ -1,0 +1,17 @@
+-module(mod_ginger_base_g_string_tests).
+
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+contains_test() ->
+    ?assert(g_string:contains("foo", "foo")),
+    ?assert(g_string:contains("foo", "barfoobaz")),
+    ?assert(g_string:contains("foo", "barfoo")),
+    ?assert(g_string:contains("foo", "foobar")),
+    ?assert(g_string:contains("", "foo")),
+    ?assert(g_string:contains("", "")),
+    ?assertNot(g_string:contains("foo", "")),
+    ?assertNot(g_string:contains("foo", "bar")),
+    ?assertNot(g_string:contains("foo", "oof")),
+    %% Done
+    ok.


### PR DESCRIPTION
Let's start making a collection of functions we keep rewriting every project cause they're missing in the erlang std libs.

`g_*` Seems like a good naming scheme filled with puns.