### PR TITLE
Remove unnecessary 'isPrimaryTopic' filter from DBpedia Sparql query

### DIFF
--- a/modules/mod_ginger_rdf/support/dbpedia.erl
+++ b/modules/mod_ginger_rdf/support/dbpedia.erl
@@ -20,9 +20,7 @@ search(#search_query{search = {dbpedia, Args}, offsetlimit = {Offset, Limit}}) -
     Predicates = proplists:get_value(properties, Args, default_properties()),
     Wheres = [parse_argument(Key, Value) || {Key, Value} <- Args] ++ [
         %% Exclude redirect pages.
-        <<"FILTER NOT EXISTS {?s <http://dbpedia.org/ontology/wikiPageRedirects> []} ">>,
-        %% Only include resources that have a Wikipedia page.
-        <<"FILTER EXISTS {?s <", (rdf_property:foaf(<<"isPrimaryTopicOf">>))/binary, "> []} ">>
+        <<"FILTER NOT EXISTS {?s <http://dbpedia.org/ontology/wikiPageRedirects> []} ">>
     ],
     Query =
         sparql_query:limit(Limit,


### PR DESCRIPTION
This filter prevented us from seeing useful data, and the check for the wiki
link is done in the templates as well, so is unnecessary here.