### PR TITLE
[base] Add check around getFacets

### DIFF
--- a/modules/mod_ginger_base/lib/js/search/search_ui.js
+++ b/modules/mod_ginger_base/lib/js/search/search_ui.js
@@ -71,7 +71,9 @@ $.widget("ui.search_ui", {
 
         // This should be ~pagesession, but see https://github.com/zotonic/zotonic/issues/1622
         pubzub.subscribe("~session/search/facets", function (topic, msg) {
-            me.setFacets(msg.payload);
+            if (msg.payload) {
+                me.setFacets(msg.payload);
+            }
         });
 
     },


### PR DESCRIPTION
When there zero facets in the searchwidgets the search would break since it can't find facets