### PR TITLE
[base] Return 200 with object on GET auth status request instead of http error

### DIFF
--- a/modules/mod_ginger_base/controllers/controller_auth.erl
+++ b/modules/mod_ginger_base/controllers/controller_auth.erl
@@ -118,7 +118,8 @@ to_json(_Req, State = #state{mode = status}) ->
     Context = State#state.context,
     case z_acl:user(Context) of
         undefined ->
-            {{halt, 400}, Context#context.wm_reqdata, State};
+            Body = jsx:encode(#{<<"status">> => <<"anonymous">>}),
+            {Body, Context#context.wm_reqdata, State};
         Id ->
             Body = jsx:encode(user(Id, Context)),
             {Body, Context#context.wm_reqdata, State}


### PR DESCRIPTION
Return `{status: anonymous}` instead of a http error if you're not signed in.

You're allowed to get the status, even if it's anonymous.

This also prevents logging console errors in the browser every time you load the page.