### PR TITLE
Use tabs_enabled to define the order of the default find/new/upload/url tabs.

### DIFF
--- a/modules/mod_ginger_edit/templates/_action_ginger_dialog_connect.tpl
+++ b/modules/mod_ginger_edit/templates/_action_ginger_dialog_connect.tpl
@@ -11,56 +11,63 @@
 {% with objects++author as objects %}
     <ul class="nav nav-pills">
         {% block tabs %}
-        {% if cat_name!='keyword' %}
-            {% if not (tabs_enabled and tabs_enabled|length == 1) %}
+            {% if cat_name != 'keyword' %}
+                {% for t in tabs_enabled|default:[ "find", "new", "upload", "url" ] %}
+                    {% if not (tabs_enabled and tabs_enabled|length == 1) %}
+                        {% if t == "find" %}
+                            {% if "find"|member:tabs_enabled %}
+                                <li {% if tab == "find" %}class="active"{% endif %}>
+                                    <a data-toggle="tab" data-id="{{m.rsc[cat_name].id}}" data-name="{{cat_name}}" href="#{{ #tab }}-find">{_ Find Page _}</a>
+                                </li>
+                            {% endif %}
+                        {% elseif t == "new" %}
+                            {% if "new"|member:tabs_enabled %}
+                                <li {% if tab == "new" %}class="active"{% endif %}>
+                                    <a data-toggle="tab" href="#{{ #tab }}-new">{_ New Page _}</a>
+                                </li>
+                            {% endif %}
+                        {% elseif t == "upload" %}
+                            {% if "upload"|member:tabs_enabled %}
+                                <li {% if tab == "upload" %}class="active"{% endif %}>
+                                    <a data-toggle="tab" href="#{{ #tab }}-upload">{_ Upload File _}</a>
+                                </li>
+                            {% endif %}
+                        {% elseif t == "url" %}
+                            {% if "url"|member:tabs_enabled %}
+                                <li {% if tab == "url" %}class="active"{% endif %}>
+                                    <a data-toggle="tab" href="#{{ #tab }}-url">{_ Upload by URL _}</a>
+                                </li>
+                            {% endif %}
+                        {% endif %}
+                    {% endif %}
+                {% endfor %}
+            {% else %}
+                {% block keyword_tabs %}
                 {% if "find"|member:tabs_enabled %}
+                    {% with m.category[m.rsc.keyword.id].tree1 as hassubs %}
                     <li {% if tab == "find" %}class="active"{% endif %}>
-                        <a data-toggle="tab" data-id="{{m.rsc[cat_name].id}}" data-name="{{cat_name}}" href="#{{ #tab }}-find">{_ Find Page _}</a>
+                        <a data-toggle="tab" data-id="{{m.rsc["keyword"].id}}" data-name="keyword" href="#{{ #tab }}-find" id='tab-button-keyword'>{% if hassubs %}{_ All _}{% else %}{_ Find _}{% endif %}</a>
                     </li>
+                    {% if hassubs %}
+                        {% for child in m.category[m.rsc.keyword.id].tree1 %}
+                            {% with m.rsc[child.id].name as name %}
+                            <li {% if tab == "{{ name }}" %}class="active"{% endif %}>
+                                <a data-toggle="tab" data-id="{{m.rsc[name].id}}" data-name="{{name}}" href="#{{ #tab }}-find" id='tab-button-{{ name }}'>{{ m.rsc[name].title }}</a>
+                            </li>
+                            {% endwith %}
+                        {% endfor %}
+                    {% endif %}
+                    {% endwith %}
                 {% endif %}
-                {% if "new"|member:tabs_enabled %}
+                {% if m.acl.insert[cat_name] and "new"|member:tabs_enabled %}
                     <li {% if tab == "new" %}class="active"{% endif %}>
-                        <a data-toggle="tab" href="#{{ #tab }}-new">{_ New Page _}</a>
+                        <a data-toggle="tab" href="#{{ #tab }}-new">{_ New _}</a>
                     </li>
                 {% endif %}
-                {% if "upload"|member:tabs_enabled %}
-                    <li {% if tab == "upload" %}class="active"{% endif %}>
-                        <a data-toggle="tab" href="#{{ #tab }}-upload">{_ Upload File _}</a>
-                    </li>
-                {% endif %}
-                {% if "url"|member:tabs_enabled %}
-                    <li {% if tab == "url" %}class="active"{% endif %}>
-                        <a data-toggle="tab" href="#{{ #tab }}-url">{_ Upload by URL _}</a>
-                    </li>
-                {% endif %}
+                {% endblock %}
             {% endif %}
-        {% else %}
-            {% block keyword_tabs %}
-            {% if "find"|member:tabs_enabled %}
-                {% with m.category[m.rsc.keyword.id].tree1 as hassubs %}
-                <li {% if tab == "find" %}class="active"{% endif %}>
-                    <a data-toggle="tab" data-id="{{m.rsc["keyword"].id}}" data-name="keyword" href="#{{ #tab }}-find" id='tab-button-keyword'>{% if hassubs %}{_ All _}{% else %}{_ Find _}{% endif %}</a>
-                </li>
-                {% if hassubs %}
-                    {% for child in m.category[m.rsc.keyword.id].tree1 %}
-                        {% with m.rsc[child.id].name as name %}
-                        <li {% if tab == "{{ name }}" %}class="active"{% endif %}>
-                            <a data-toggle="tab" data-id="{{m.rsc[name].id}}" data-name="{{name}}" href="#{{ #tab }}-find" id='tab-button-{{ name }}'>{{ m.rsc[name].title }}</a>
-                        </li>
-                        {% endwith %}
-                    {% endfor %}
-                {% endif %}
-                {% endwith %}
-            {% endif %}
-            {% if m.acl.insert[cat_name] and "new"|member:tabs_enabled %}
-                <li {% if tab == "new" %}class="active"{% endif %}>
-                    <a data-toggle="tab" href="#{{ #tab }}-new">{_ New _}</a>
-                </li>
-            {% endif %}
-            {% endblock %}
-        {% endif %}
 
-        {% all include "_media_upload_tab.tpl" tab=#tab %}
+            {% all include "_media_upload_tab.tpl" tab=#tab %}
 
         {% endblock %}
     </ul>


### PR DESCRIPTION
This is to support tab order as requested in issue OR-308.

I checked the Ginger sources and this would not change any default tab order used there.