### PR TITLE
Include geomap js on ginger-edit page.

### DIFF
--- a/modules/mod_ginger_edit/templates/_ginger_edit_js_include.tpl
+++ b/modules/mod_ginger_edit/templates/_ginger_edit_js_include.tpl
@@ -48,6 +48,10 @@
     {% lib "js/admin-geo.js" %}
 {% endif %}
 
+{% if m.modules.active.mod_geomap %}
+    {% include "_js_geomap.tpl" %}
+{% endif %}
+
 {% if m.modules.active.mod_admin_multiupload and m.acl.is_allowed.use.mod_admin_multiupload %}
     {% lib "js/jquery.fileupload.js" %}
 {% endif %}


### PR DESCRIPTION
This is needed to support mod_geomap in ginger-edit (as ginger edit does not have the include all of `_js_admin.tpl`)