### PR TITLE
[Skel] Remove ACL fixtures from dev data

### DIFF
--- a/skel/support/SITE_data_fixtures.erl
+++ b/skel/support/SITE_data_fixtures.erl
@@ -103,10 +103,6 @@ get_dev_data(Context) ->
         ],
         edges = [
             % {unique_name, predicate, unique_name}
-        ],
-        data = [
-            % Can't have acl_rules here as it would replace the ACL rules from
-            % the prod_data.
         ]
     }.
 


### PR DESCRIPTION
- ACL fixtures should only and always be implemented in the prod fixtures