### PR TITLE
[rdf] Export JSON-LD consistently in expanded form

### DIFF
--- a/modules/mod_ginger_rdf/tests/m_rdf_tests.erl
+++ b/modules/mod_ginger_rdf/tests/m_rdf_tests.erl
@@ -75,11 +75,11 @@ m_find_value_test() ->
         m_rdf:m_find_value(<<"single_value">>, #m{value = Input}, ContextWithLanguage)
     ),
     ?assertEqual(
-        [<<"Value2">>],
+        <<"Value2">>,
         m_rdf:m_find_value(<<"single_value_in_list">>, #m{value = Input}, ContextWithLanguage)
     ),
     ?assertEqual(
-        [<<"Value3">>],
+        undefined,
         m_rdf:m_find_value(<<"nonrecord_content_in_list">>, #m{value = Input}, ContextWithLanguage)
     ),
     ?assertEqual(

--- a/modules/mod_ginger_rdf/tests/mod_ginger_rdf_tests.erl
+++ b/modules/mod_ginger_rdf/tests/mod_ginger_rdf_tests.erl
@@ -33,12 +33,20 @@ serialize_to_map_test() ->
     Map = ginger_json_ld:serialize_to_map(Resource),
     Expected = #{
         <<"@id">> => <<"http://dinges.com/123">>,
-        <<"dcterms:abstract">> => #{<<"@value">> => <<"Good story bro!">>},
-        <<"dcterms:creator">> => #{
-            <<"@id">> => <<"http://dinges.com/456">>,
-            <<"rdfs:label">> => #{<<"@value">> => <<"Pietje Puk">>}
-        },
-        <<"owl:sameAs">> => #{<<"@id">> => <<"http://nl.dbpedia.org/resource/Dinges">>}
+        <<"dcterms:abstract">> => [
+            #{<<"@value">> => <<"Good story bro!">>}
+        ],
+        <<"dcterms:creator">> => [
+            #{
+                <<"@id">> => <<"http://dinges.com/456">>,
+                <<"rdfs:label">> => [
+                    #{<<"@value">> => <<"Pietje Puk">>}
+                ]
+            }
+        ],
+        <<"owl:sameAs">> => [
+            #{<<"@id">> => <<"http://nl.dbpedia.org/resource/Dinges">>}
+        ]
     },
     ?assertEqual(Expected, Map).
 
@@ -76,20 +84,30 @@ serialize_multiple_levels_to_map_test() ->
     Map = ginger_json_ld:serialize_to_map(Resource),
     Expected = #{
         <<"@id">> => <<"http://dinges.com/123">>,
-        <<"dcterms:abstract">> => #{<<"@value">> => <<"Good story bro!">>},
-        <<"dcterms:creator">> => #{
-            <<"@id">> => <<"http://dinges.com/456">>,
-            <<"rdfs:label">> => #{<<"@value">> => <<"Pietje Puk">>},
-            <<"dcterms:publisher">> => #{
-                <<"@id">> => <<"http://dinges.com/789">>,
-                <<"rdfs:label">> => #{<<"@value">> => <<"De uitgever">>}
+        <<"dcterms:abstract">> => [
+            #{<<"@value">> => <<"Good story bro!">>}
+        ],
+        <<"dcterms:creator">> => [
+            #{
+                <<"@id">> => <<"http://dinges.com/456">>,
+                <<"rdfs:label">> => [
+                    #{<<"@value">> => <<"Pietje Puk">>}
+                ],
+                <<"dcterms:publisher">> => [
+                    #{
+                        <<"@id">> => <<"http://dinges.com/789">>,
+                        <<"rdfs:label">> => [
+                            #{<<"@value">> => <<"De uitgever">>}
+                        ]
+                    }
+                ]
             }
-        }
+        ]
     },
     ?assertEqual(Expected, Map).
 
 serialize_recursive_test() ->
-     Resource = #rdf_resource{
+    Resource = #rdf_resource{
         id = <<"http://dinges.com/123">>,
         triples = [
             #triple{
@@ -102,7 +120,9 @@ serialize_recursive_test() ->
     Map = ginger_json_ld:serialize_to_map(Resource),
     Expected = #{
         <<"@id">> => <<"http://dinges.com/123">>,
-        <<"owl:sameAs">> => <<"http://dinges.com/123">>
+        <<"owl:sameAs">> => [
+            <<"http://dinges.com/123">>
+        ]
     },
     ?assertEqual(Expected, Map).
 
@@ -124,19 +144,21 @@ rdf_export_test() ->
             <<"@type">> => #{
                 <<"@id">> => <<"http://purl.org/dc/dcmitype/Text">>
             },
-            <<"http://schema.org/dateCreated">> =>
-                #{<<"@value">> => m_rsc:p(Id, created, Context)
-            },
-            <<"http://schema.org/dateModified">> => #{
-                <<"@value">> => m_rsc:p(Id, modified, Context)
-            },
-            <<"http://schema.org/datePublished">> => #{
-                <<"@value">> => m_rsc:p(Id, publication_start, Context)
-            },
-            <<"http://schema.org/headline">> => #{
-                <<"@value">> => <<"Een mooie titel">>,
-                <<"@language">> => nl
-            }
+            <<"http://schema.org/dateCreated">> => [
+                #{<<"@value">> => m_rsc:p(Id, created, Context)}
+            ],
+            <<"http://schema.org/dateModified">> => [
+                #{<<"@value">> => m_rsc:p(Id, modified, Context)}
+            ],
+            <<"http://schema.org/datePublished">> => [
+                #{<<"@value">> => m_rsc:p(Id, publication_start, Context)}
+            ],
+            <<"http://schema.org/headline">> => [
+                #{
+                    <<"@value">> => <<"Een mooie titel">>,
+                    <<"@language">> => nl
+                }
+            ]
         },
         Map
     ).
@@ -164,25 +186,34 @@ address_to_triples_test() ->
     Map = ginger_json_ld:serialize_to_map(#rdf_resource{triples = Triples}),
     ?assertEqual(
         #{
-            <<"http://schema.org/location">> => #{
-                <<"@type">> => #{
-                    <<"@id">> => <<"http://schema.org/Place">>
-                },
-                <<"http://schema.org/address">> => #{
+            <<"http://schema.org/location">> => [
+                #{
                     <<"@type">> => #{
-                        <<"@id">> => <<"http://schema.org/PostalAddress">>
+                        <<"@id">> => <<"http://schema.org/Place">>
                     },
-                    <<"http://schema.org/streetAddress">> => #{
-                        <<"@value">> => <<"Oudezijds Voorburgwal 282">>
-                    },
-                    <<"http://schema.org/addressLocality">> => #{
-                        <<"@value">> => <<"Amsterdam">>
-                    },
-                    <<"http://schema.org/addressCountry">> => #{
-                        <<"@value">> => <<"Nederland">>
-                    }
+                    <<"http://schema.org/address">> => [
+                        #{
+                            <<"@type">> => #{
+                                <<"@id">> => <<"http://schema.org/PostalAddress">>
+                            },
+                            <<"http://schema.org/streetAddress">> => [
+                                #{
+                                    <<"@value">> => <<"Oudezijds Voorburgwal 282">>
+                                }
+                            ],
+                            <<"http://schema.org/addressLocality">> => [
+                                #{
+                                    <<"@value">> => <<"Amsterdam">>
+                                }
+                            ],
+                            <<"http://schema.org/addressCountry">> => [
+                                #{
+                                    <<"@value">> => <<"Nederland">>
+                                }
+                            ]
+                        }]
                 }
-            }
+            ]
         },
         Map
     ).

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-MODULES="controller_rest_edges controller_rest_resources $(ls ebin/*ginger*tests.beam|sed -e 's|ebin/||'|sed -e 's|.beam||')"
+MODULES="controller_rest_edges controller_rest_resources m_rdf_tests $(ls ebin/*ginger*tests.beam|sed -e 's|ebin/||'|sed -e 's|.beam||')"
 bin/zotonic runtests $MODULES


### PR DESCRIPTION
All predicates should contain lists of objects; see
https://w3c.github.io/json-ld-syntax/#expanded-document-form.