### PR TITLE
Always filter resources that have is_unfindable=true

### DIFF
--- a/modules/mod_ginger_base/controllers/controller_search.erl
+++ b/modules/mod_ginger_base/controllers/controller_search.erl
@@ -61,8 +61,11 @@ params(Req) ->
 -spec arguments(wrq:rd()) -> proplists:proplist().
 arguments(Req) ->
     RequestArgs = wrq:req_qs(Req),
+    Default = {filter, ["is_unfindable", '<>', true]},
     Arguments = [argument({list_to_existing_atom(Key), Value}) || {Key, Value} <- RequestArgs],
-    [{Key, Value} || {Key, Value} <- Arguments, lists:member(Key, whitelist())].
+    FilteredArguments =
+        [{Key, Value} || {Key, Value} <- Arguments, lists:member(Key, whitelist())],
+    [Default|FilteredArguments].
 
 %% @doc Pre-process request argument if needed.
 -spec argument({atom(), list() | binary()}) -> {atom(), list() | binary()}.


### PR DESCRIPTION
Added to the search api endpoint

The resources endpoint continues to return resources that have `is_unfindable` set to `true`