### PR TITLE
Remove jsx dependency from docker and sample config

### DIFF
--- a/config/zotonic.config
+++ b/config/zotonic.config
@@ -8,7 +8,6 @@
             {geodata2, ".*", {git, "https://github.com/brigadier/geodata2.git", "1a4da299683691d6de19b9f261f53b5ea6e10407"}},
             {hackney, ".*", {git, "https://github.com/benoitc/hackney.git", {tag, "1.14.3"}}},
             {hamcrest, ".*", {git, "https://github.com/truqu/hamcrest-erlang", "e413409e9424751865bd58d65c49fa6659d94d2d"}},
-            {jsx, ".*", {git, "https://github.com/talentdeficit/jsx.git", {tag, "2.8.0"}}},
             {lager_logstash, "", {git, "https://github.com/rpt/lager_logstash.git", {tag, "0.1.3"}}},
             {tql, ".*", {git, "https://github.com/driebit/tql", {tag, "1.2.1"}}}
         ]}

--- a/docker/prod/etc_zotonic/zotonic.config
+++ b/docker/prod/etc_zotonic/zotonic.config
@@ -7,7 +7,6 @@
     {deps, [
         {erlastic_search, ".*", {git, "https://github.com/tsloughter/erlastic_search.git", "6478cc5d915413a7162515a19fa705296c605823"}},
         {geodata2, ".*", {git, "https://github.com/brigadier/geodata2.git", "1a4da299683691d6de19b9f261f53b5ea6e10407"}},
-        {hackney, ".*", {git, "https://github.com/benoitc/hackney.git", {tag, "1.6.1"}}},
-        {jsx, ".*", {git, "https://github.com/talentdeficit/jsx.git", {tag, "2.8.0"}}}
+        {hackney, ".*", {git, "https://github.com/benoitc/hackney.git", {tag, "1.6.1"}}}
     ]}
 ]}].


### PR DESCRIPTION
Zotonic 0.x now depends on jsx 3.0.0