### PR TITLE
mod_ginger_rdf: split _html_head.tpl

### DIFF
--- a/modules/mod_ginger_rdf/support/ginger_json_ld.erl
+++ b/modules/mod_ginger_rdf/support/ginger_json_ld.erl
@@ -76,7 +76,7 @@ resolve_predicate(Predicate, Context) ->
             %% Predicate with namespace, e.g, "dcterms:date"
             case resolve_context_key(Namespace, Context) of
                 undefined ->
-                    lager:error("Namespace ~p not registered", [Namespace]),
+                    lager:error("Namespace ~p for ~p not registered", [Namespace, Predicate]),
                     undefined;
                 ResolvedNamespace ->
                     erlang:iolist_to_binary([ResolvedNamespace, Property])

--- a/modules/mod_ginger_rdf/templates/_html_head.tpl
+++ b/modules/mod_ginger_rdf/templates/_html_head.tpl
@@ -1,1 +1,3 @@
-    <link rel="alternate" type="application/ld+json" href="{% url rsc_json_ld id=id %}">
+{% if id %}
+    {% include "_html_head_ginger_rdf.tpl" %}
+{% endif %}

--- a/modules/mod_ginger_rdf/templates/_html_head_ginger_rdf.tpl
+++ b/modules/mod_ginger_rdf/templates/_html_head_ginger_rdf.tpl
@@ -1,0 +1,1 @@
+    <link rel="alternate" type="application/ld+json" href="{% url rsc_json_ld id=id %}">


### PR DESCRIPTION
 * Adds '_html_head_ginger_rdf.tpl' for easier overrule of the json-ld link.
 * Better error message on missing namespace.