### PR TITLE
[rdf] Export only visible edges

### DIFF
--- a/modules/mod_ginger_rdf/README.md
+++ b/modules/mod_ginger_rdf/README.md
@@ -23,29 +23,38 @@ Features
 
 ### Represent resources in RDF
 
-Enable mod_ginger_rdf in Zotonic, then request any page with content negotation,
-using the proper Accept header to get an RDF representation of the resource
-(where `123` is the id of some resource):
+Enable mod_ginger_rdf in Zotonic, then request any page with content
+negotiation, using the proper Accept header to get an RDF representation of the
+resource at its URI (where `123` is the id of some resource):
 
 ```bash
 curl -L -H Accept:application/ld+json http://yoursite.com/id/123
+curl -L -H Accept:text/turtle http://yoursite.com/id/123
 ```
 
-Only visible (published) resources will return data; any invisible resource
-returns a 404.
+For viewing in the browser, the JSON-LD RDF representation is also available at
+`http://yoursite.com/rdf/123`.
 
-Only predicates and categories with a real URI will be included in the output.
-If you’re missing one of your custom predicates, give it the URI of some
-property in one of the linked data vocabularies (for
-example `https://schema.org/Person`). You can do so in the admin, on the
-predicate’s edit page, under ‘Advanced’.
+#### Export rules
 
-The default representation uses
-the [Schema.org vocabulary](support/schema_org.erl), as
-[recommended by NDE](https://netwerk-digitaal-erfgoed.github.io/cm-implementation-guidelines/#generic-data-model).
+The RDF export follows some rules.
+
+- Only visible (published) resources return data; any invisible resource returns
+  a 404.
+- Only edges with visible (published) objects are included in the output.
+- Only predicates that have a real URI are included in the output, so if you’re
+  missing a predicate, give it the URI of some property in one of the linked
+  data vocabularies (for example `http://schema.org/about`). You can do so in
+  the admin, on the predicate’s edit page, under ‘Advanced’.
+- The default representation uses the
+  [Schema.org vocabulary](support/schema_org.erl), as
+  [recommended by NDE](https://netwerk-digitaal-erfgoed.github.io/cm-implementation-guidelines/#generic-data-model).
+- Vocabularies can decide to include or exclude specific predicates.
 
 Observe the [`#rsc_to_rdf{}`](#changing-the-rdf-representation) notification to
-hook into the process.
+hook into the export process.
+
+#### JSON-LD serialization
 
 This JSON-LD serialization happens in two steps:
 

--- a/modules/mod_ginger_rdf/models/m_rdf_export.erl
+++ b/modules/mod_ginger_rdf/models/m_rdf_export.erl
@@ -59,6 +59,7 @@ edges_to_triples(Edges, Ontologies, Context) ->
     lists:filtermap(
         fun({Predicate, EdgesForPredicate}) ->
             Uri = m_rsc:p(Predicate, uri, Context),
+            VisibleEdgesForPredicate = lists:filter(fun (Edge) -> edge_is_visible(Edge, Context) end, EdgesForPredicate),
             case lists:flatten([
                 Ontology:edge_to_triples(
                     Predicate,
@@ -67,7 +68,7 @@ edges_to_triples(Edges, Ontologies, Context) ->
                     proplists:get_value(object_id, Edge),
                     Context
                 )
-                || Edge <- EdgesForPredicate, Ontology <- Ontologies
+                || Edge <- VisibleEdgesForPredicate, Ontology <- Ontologies
             ]) of
                 [] ->
                     false;
@@ -77,6 +78,11 @@ edges_to_triples(Edges, Ontologies, Context) ->
         end,
         Edges
     ).
+
+%% @doc The visibility of a Zotonic edge is determined by the visibility of its object.
+-spec edge_is_visible(proplists:proplist(), z:context()) -> boolean().
+edge_is_visible(Edge, Context) ->
+    m_rsc:is_visible(proplists:get_value(object_id, Edge), Context).
 
 -spec types(m_rsc:resource(), z:context()) -> [m_rdf:triple()].
 types(Category, Context) ->


### PR DESCRIPTION
We already publish RDF only for visible (published) subject resources, 
so do the same for any edges in those resources: filter them by visibility.