### PR TITLE
mod_ginger_rdf: add caching of dbpedia lookups in the tkvstore.

### DIFF
--- a/modules/mod_ginger_base/support/ginger_http_client.erl
+++ b/modules/mod_ginger_base/support/ginger_http_client.erl
@@ -12,8 +12,8 @@
     url_with_query_string/2
 ]).
 
-%% Total request timeout - 10 minutes
--define(HTTPC_TIMEOUT, 600000).
+%% Total request timeout - 30 minutes
+-define(HTTPC_TIMEOUT, 1800000).
 
 %% Connect timeout, server has to respond before this - 20 seconds
 -define(HTTPC_TIMEOUT_CONNECT, 20000).

--- a/modules/mod_ginger_base/support/ginger_http_client.erl
+++ b/modules/mod_ginger_base/support/ginger_http_client.erl
@@ -12,6 +12,13 @@
     url_with_query_string/2
 ]).
 
+%% Total request timeout - 10 minutes
+-define(HTTPC_TIMEOUT, 600000).
+
+%% Connect timeout, server has to respond before this - 20 seconds
+-define(HTTPC_TIMEOUT_CONNECT, 20000).
+
+
 %% @doc GET a URL.
 -spec get(string()) -> map() | undefined.
 get(Url) ->
@@ -44,8 +51,12 @@ request(Method, Url, Headers) when is_binary(Url) ->
     request(Method, binary_to_list(Url), Headers);
 request(get, Url, Headers) ->
     lager:debug("ginger_http_client GET: ~s ~p", [Url, Headers]),
-
-    case handle_response(httpc:request(get, {Url, Headers}, [], []), Url) of
+    Result = httpc:request(
+        get,
+        {Url, Headers},
+        http_options(),
+        httpc_options()),
+    case handle_response(Result, Url) of
         {error, _} ->
             undefined;
         Response ->
@@ -54,12 +65,33 @@ request(get, Url, Headers) ->
 
 request(RequestMethod, Url, Headers, Data) ->
     JsonData = jsx:encode(Data),
-    case handle_response(httpc:request(RequestMethod, {Url, Headers, "application/json", JsonData}, [], []), Url) of
+    Result = httpc:request(
+        RequestMethod,
+        {Url, Headers, "application/json", JsonData},
+        http_options(),
+        httpc_options()),
+    case handle_response(Result, Url) of
         {error, _} ->
             undefined;
         Response ->
             decode(Response)
     end.
+
+% Use ssl {verify, verify_none} as we don't have the tls_certificates
+% application installed in Ginger 0.x sites.
+http_options() ->
+    [
+        {ssl, [{verify, verify_none}]},
+        {autoredirect, true},
+        {relaxed, true},
+        {timeout, ?HTTPC_TIMEOUT},
+        {connect_timeout, ?HTTPC_TIMEOUT_CONNECT}
+    ].
+
+httpc_options() ->
+    [
+        {body_format, binary}
+    ].
 
 url_with_query_string(Url, Params) when is_map(Params) ->
     url_with_query_string(Url, maps:to_list(Params));
@@ -84,13 +116,13 @@ handle_response(Response, Url) ->
             Body
         }} when StatusCode >= 400 ->
             lager:error("~p error ~p for URL ~p: ~p", [?MODULE, StatusCode, Url, Body]),
-            {error, {StatusCode, list_to_binary(Body)}};
+            {error, {StatusCode, Body}};
         {ok, {
             {_HTTP, _StatusCode, _OK},
             Headers,
             Body
         }} ->
-            {proplists:get_value("content-type", Headers), list_to_binary(Body)};
+            {proplists:get_value("content-type", Headers), Body};
         JsonResponse ->
             lager:error("~p unknown error for URL ~p: ~p", [?MODULE, Url, JsonResponse]),
             {error, JsonResponse}

--- a/modules/mod_ginger_rdf/models/m_dbpedia.erl
+++ b/modules/mod_ginger_rdf/models/m_dbpedia.erl
@@ -16,8 +16,11 @@
     is_wikidata_uri/1
 ]).
 
+-define(CACHE_TYPE, <<"m_dbpedia:uri:fetch">>).
+
+
 %% @doc Usage: m.dbpedia["http://nl.dbpedia.org/resource/Nederland"]
--spec m_find_value(ginger_uri:uri() | atom(), #m{}, z:context()) -> #rdf_resource{}.
+-spec m_find_value(ginger_uri:uri() | atom(), #m{}, z:context()) -> m_rdf:rdf_resource().
 m_find_value(<<"http://", Uri/binary>>, #m{}, Context) ->
     get_resource(Uri, Context);
 m_find_value(<<"https://", Uri/binary>>, #m{}, Context) ->
@@ -34,7 +37,7 @@ m_value(#m{value = Uri}, Context) ->
     get_resource(Uri, Context, nl).
 
 %% @doc Get a resource from DBPedia or WikiData.
--spec get_resource(binary(), z:context()) -> #rdf_resource{} | undefined.
+-spec get_resource(binary(), z:context()) -> m_rdf:rdf_resource() | undefined.
 get_resource(<<"http://", Url/binary>>, Context) ->
     get_resource(Url, Context);
 get_resource(<<"https://", Url/binary>>, Context) ->
@@ -46,14 +49,66 @@ get_resource(<<"nl.dbpedia.org", _/binary>> = Uri, Context) ->
 get_resource(<<"dbpedia.org", _/binary>> = Uri, Context) ->
     get_resource(Uri, <<>>, Context).
 
+-spec get_resource(Uri::binary(), Language::binary(), z:context()) -> m_rdf:rdf_resource() | undefined.
 get_resource(Uri, Language, Context) ->
-    z_depcache:memo(
-        fun() ->
-            dbpedia:get_resource(<<"http://", Uri/binary>>, Language)
-        end,
-        {Uri, Language},
-        Context
-    ).
+            get_resource_cached(Uri, Language, Context).
+    % z_depcache:memo(
+    %     fun() ->
+    %         get_resource_cached(Uri, Language, Context)
+    %     end,
+    %     {Uri, Language},
+    %     Context
+    % ).
+
+get_resource_cached(Uri, Language, Context) ->
+    case cache_lookup(Uri, Language, Context) of
+        {error, enoent} ->
+            get_resource_fetch(Uri, Language, undefined, Context);
+        {ok, {stale, Data}} ->
+            % Try to refresh the cached data
+            get_resource_fetch(Uri, Language, Data, Context);
+        {ok, {valid, Data}} ->
+            Data
+    end.
+
+get_resource_fetch(Uri, Language, StaleData, Context) ->
+    Key = cache_key(Uri, Language),
+    case dbpedia:get_resource(<<"http://", Uri/binary>>, Language) of
+        undefined ->
+            % Store errornous or stale data for an hour
+            Till = z_datetime:next_hour( calendar:universal_time() ),
+            TkvData = {dbpedia, StaleData, Till},
+            z_notifier:first(
+                #tkvstore_put{ type = ?CACHE_TYPE, key = Key, value = TkvData},
+                Context),
+            StaleData;
+        Data ->
+            % Store valid lookups for a day
+            Till = z_datetime:next_day( calendar:universal_time() ),
+            TkvData = {dbpedia, Data, Till},
+            z_notifier:first(
+                #tkvstore_put{ type = ?CACHE_TYPE, key = Key, value = TkvData},
+                Context),
+            Data
+    end.
+
+cache_lookup(Uri, Language, Context) ->
+    Key = cache_key(Uri, Language),
+    case z_notifier:first(#tkvstore_get{ type = ?CACHE_TYPE, key = Key }, Context) of
+        undefined ->
+            {error, enoent};
+        {dbpedia, Data, ValidTill} ->
+            case ValidTill >= calendar:universal_time() of
+                true ->
+                    {ok, {valid, Data}};
+                false ->
+                    {ok, {stale, Data}}
+            end
+    end.
+
+cache_key(Uri, Language) ->
+    iolist_to_binary( z_utils:hex_encode( crypto:hash(sha, [ Uri, "::", Language ]) ) ).
+
 
 %% @doc Does the URI belong to DBPedia?
 -spec is_dbpedia_uri(binary()) -> boolean().


### PR DESCRIPTION
This fixes an issue where keyword metadata is not show if nl.dbpedia.org is down.