### PR TITLE
[rdf] Serialize queries as Hydra collections

### DIFF
--- a/modules/mod_ginger_rdf/README.md
+++ b/modules/mod_ginger_rdf/README.md
@@ -13,6 +13,7 @@ Features:
 
 1. [Features](#features)
    * [Represent resources in RDF](#represent-resources-in-rdf)
+   * [Represent collections in RDF](#represent-collections-in-rdf)
    * [Inline JSON-LD](#inline-json-ld)
    * [Link Zotonic resources to linked data](#link-zotonic-resources-to-linked-data)
 2. [Notifications](#notifications)
@@ -34,6 +35,18 @@ curl -L -H Accept:text/turtle http://yoursite.com/id/123
 
 For viewing in the browser, the JSON-LD RDF representation is also available at
 `http://yoursite.com/rdf/123`.
+
+#### Represent collections in RDF
+
+Resource collections, including resources of the category `collection`, `query`
+and their subcategories, can be represented as
+[Hydra](https://www.hydra-cg.com/spec/latest/core/) collections. Hydra offers
+standardized, machine-readable pagination.
+
+```bash
+curl -L -H Accept:application/ld+json http://yoursite.com/hydra/123
+curl -L -H Accept:text/turtle http://yoursite.com/hydra/123
+```
 
 #### Export rules
 

--- a/modules/mod_ginger_rdf/controllers/controller_hydra.erl
+++ b/modules/mod_ginger_rdf/controllers/controller_hydra.erl
@@ -1,0 +1,154 @@
+%% @doc Serve Hydra representation of a collection resource or one of its subcategories.
+%% @see https://www.hydra-cg.com/spec/latest/core/
+-module(controller_hydra).
+-author("David de Boer <david@ddeboer.nl>").
+
+-export([
+    init/1,
+    service_available/2,
+    resource_exists/2,
+    content_types_provided/2,
+    to_json_ld/2,
+    to_turtle/2
+]).
+
+-include_lib("controller_webmachine_helper.hrl").
+-include_lib("zotonic.hrl").
+-include_lib("../include/rdf.hrl").
+
+-record(state, {
+    ontology :: atom(),
+    limit :: non_neg_integer(),
+    context :: z:context()
+}).
+
+init(Args) ->
+    {ok, Args}.
+
+service_available(ReqData, Args) ->
+    Context = z_context:new_request(ReqData, [], ?MODULE),
+    Context2 = cors_headers:allow_all_cors(Context),
+    State = #state{
+        context = Context2,
+        ontology = proplists:get_value(ontology, Args),
+        limit = proplists:get_value(limit, Args, 100)
+    },
+    case wrq:method(ReqData) of
+        'OPTIONS' ->
+            {{halt, 204}, z_context:get_reqdata(Context), State};
+        _ ->
+            {true, z_context:get_reqdata(Context), State}
+    end.
+
+resource_exists(ReqData, State = #state{context = Context}) ->
+    Context1 = ?WM_REQ(ReqData, Context),
+    Context2 = z_context:ensure_qs(Context1),
+    Id = id(Context2),
+    {m_rsc:is_visible(Id, Context2) andalso m_rsc:is_a(Id, collection, Context), ReqData, State#state{context = Context2}}.
+
+content_types_provided(ReqData, Context) ->
+    {
+        [
+            {"application/ld+json", to_json_ld},
+            {"text/turtle", to_turtle}
+        ],
+        ReqData,
+        Context
+    }.
+
+to_json_ld(ReqData, State) ->
+    {serialize(to_hydra(ReqData, State), json_ld), ReqData, State}.
+
+to_turtle(ReqData, State) ->
+    {serialize(to_hydra(ReqData, State), turtle), ReqData, State}.
+
+-spec to_hydra(#wm_reqdata{}, #state{}) -> m_rdf:resource().
+to_hydra(ReqData, State) ->
+    Context = z_context:set_reqdata(ReqData, State#state.context),
+    RequestArgs = wrq:req_qs(ReqData),
+    Page = z_convert:to_integer(proplists:get_value("page", RequestArgs, 1)),
+    QueryId = id(Context),
+    Limit = State#state.limit,
+
+    #search_result{
+        pages = Pages,
+        result = Result,
+        total = Total,
+        next = Next,
+        prev = Previous
+    } = z_search:search_pager({query, [{query_id, QueryId}]}, Page, Limit, Context),
+    RdfResults = [m_rdf_export:to_rdf(Id, [State#state.ontology], Context) || Id <- Result],
+
+    HydraCollectionUrl = hydra_url(page(RequestArgs, undefined), Context), %% The Hydra collection.
+    HydraViewUrl = hydra_url(page(RequestArgs, Page), Context), %% The paged view on the Hydra collection.
+    #rdf_resource{
+        id = HydraCollectionUrl,
+        triples = [
+            #triple{
+                subject = HydraCollectionUrl,
+                predicate = rdf_property:rdf(<<"type">>),
+                object = rdf_property:hydra(<<"Collection">>)
+            },
+            #triple{
+                subject = HydraCollectionUrl,
+                predicate = rdf_property:hydra(<<"totalItems">>),
+                object = #rdf_value{value = Total}
+            },
+            #triple{
+                subject = HydraCollectionUrl,
+                predicate = rdf_property:hydra(<<"view">>),
+                object = HydraViewUrl
+            },
+            #triple{
+                subject = HydraViewUrl,
+                predicate = rdf_property:hydra(<<"first">>),
+                object = hydra_url(page(RequestArgs, 1), Context)
+            },
+            #triple{
+                subject = HydraViewUrl,
+                predicate = rdf_property:hydra(<<"next">>),
+                object = hydra_url(page(RequestArgs, Next), Context)
+            },
+            #triple{
+                subject = HydraViewUrl,
+                predicate = rdf_property:hydra(<<"previous">>),
+                object = hydra_url(page(RequestArgs, Previous), Context)
+            },
+            #triple{
+                subject = HydraViewUrl,
+                predicate = rdf_property:hydra(<<"last">>),
+                object = hydra_url(page(RequestArgs, Pages), Context)
+            }
+            |
+            [#triple{
+                subject = HydraCollectionUrl,
+                predicate = rdf_property:hydra(<<"member">>),
+                object = RdfResult
+            } || RdfResult <- RdfResults]
+        ]
+    }.
+
+%% @doc Serialize RDF resource into one of the RDF serialization formats.
+-spec serialize(#rdf_resource{}, json_ld | turtle) -> binary().
+serialize(RdfResource, json_ld) ->
+    JsonLd = ginger_json_ld:serialize_to_map(RdfResource),
+    jsx:encode(JsonLd);
+serialize(RdfResource, turtle) ->
+    ginger_turtle:serialize(RdfResource).
+
+hydra_url(undefined, _) ->
+    undefined;
+hydra_url(QueryParams, Context) ->
+    z_dispatcher:url_for(hydra, [{use_absolute_url, true} | QueryParams], undefined, Context).
+
+page(_, false) ->
+    undefined;
+page(_, 0) ->
+    undefined;
+page(QueryParams, undefined) ->
+    proplists:delete("page", QueryParams);
+page(QueryParams, PageNumber) when is_number(PageNumber) andalso PageNumber >= 1 ->
+    [{"page", PageNumber} | proplists:delete("page", QueryParams)].
+
+id(Context) ->
+    m_rsc:rid(z_context:get_q(id, Context), Context).

--- a/modules/mod_ginger_rdf/controllers/controller_rdf.erl
+++ b/modules/mod_ginger_rdf/controllers/controller_rdf.erl
@@ -25,7 +25,7 @@ init(Args) ->
 
 service_available(ReqData, Args) ->
     Context = z_context:new_request(ReqData, [], ?MODULE),
-    Context2 = set_cors_headers(Context),
+    Context2 = cors_headers:allow_all_cors(Context),
     State = #state{
         context = Context2,
         serialization = proplists:get_value(serialization, Args),
@@ -69,24 +69,3 @@ serialize(RdfResource, json_ld) ->
     jsx:encode(JsonLd);
 serialize(RdfResource, turtle) ->
     ginger_turtle:serialize(RdfResource).
-
-%% @doc Always enable CORS for this controller.
-%%      Unlike controller_api:set_cors_header, this function doesn't look at the
-%%      configuration but unconditionally exposes this controller between
-%%      domains. This makes sharing content much easier.
-set_cors_headers(Context) ->
-    lists:foldl(
-        fun ({K, Def}, Acc) ->
-            case m_config:get_value(site, K, Def, Context) of
-                undefined ->
-                    Acc;
-                V ->
-                    z_context:set_resp_header(atom_to_list(K), V, Acc)
-            end
-        end,
-        Context,
-        [
-            {'Access-Control-Allow-Origin', "*"},
-            {'Access-Control-Max-Age', undefined}
-        ]
-    ).

--- a/modules/mod_ginger_rdf/dispatch/dispatch
+++ b/modules/mod_ginger_rdf/dispatch/dispatch
@@ -1,4 +1,5 @@
 [
     {rsc_json_ld, ["rdf", id], controller_rdf, [{serialization, json_ld}, {ontology, schema_org}]},
-    {rsc_turtle, ["turtle", id], controller_rdf, [{serialization, turtle}, {ontology, schema_org}]}
+    {rsc_turtle, ["turtle", id], controller_rdf, [{serialization, turtle}, {ontology, schema_org}]},
+    {hydra, ["hydra", id], controller_hydra, [{ontology, schema_org}]}
 ].

--- a/modules/mod_ginger_rdf/include/rdf.hrl
+++ b/modules/mod_ginger_rdf/include/rdf.hrl
@@ -3,6 +3,7 @@
 -define(NS_RDF_SCHEMA, "http://www.w3.org/2000/01/rdf-schema#").
 -define(NS_FOAF, "http://xmlns.com/foaf/0.1/").
 -define(NS_GEO, "http://www.w3.org/2003/01/geo/wgs84_pos#").
+-define(NS_HYDRA, "http://www.w3.org/ns/hydra/core#").
 -define(NS_DCTERMS, "http://purl.org/dc/terms/").
 -define(NS_DCTYPE, "http://purl.org/dc/dcmitype/").
 -define(NS_VCARD, "http://www.w3.org/2006/vcard/ns#").

--- a/modules/mod_ginger_rdf/support/cors_headers.erl
+++ b/modules/mod_ginger_rdf/support/cors_headers.erl
@@ -1,0 +1,24 @@
+-module(cors_headers).
+
+-export([
+    allow_all_cors/1
+]).
+
+%% @doc Unlike controller_api:set_cors_header, this function doesn't look at the configuration but unconditionally
+%% exposes this controller between domains. This makes sharing content much easier.
+allow_all_cors(Context) ->
+    lists:foldl(
+        fun({K, Def}, Acc) ->
+            case m_config:get_value(site, K, Def, Context) of
+                undefined ->
+                    Acc;
+                V ->
+                    z_context:set_resp_header(atom_to_list(K), V, Acc)
+            end
+        end,
+        Context,
+        [
+            {'Access-Control-Allow-Origin', "*"},
+            {'Access-Control-Max-Age', undefined}
+        ]
+    ).

--- a/modules/mod_ginger_rdf/support/ginger_json_ld.erl
+++ b/modules/mod_ginger_rdf/support/ginger_json_ld.erl
@@ -321,6 +321,8 @@ triple_to_json(#triple{type = resource, predicate = Predicate, object = Object})
 triple_to_map(#triple{object = #rdf_value{value = undefined}}, #rdf_resource{}) ->
     %% Ignore empty triples without object.
     undefined;
+triple_to_map(#triple{object = undefined}, #rdf_resource{}) ->
+    undefined;
 triple_to_map(#triple{subject = Id, predicate = <<?NS_RDF, "type">>, object = Object}, #rdf_resource{id = Id}) when is_binary(Object) ->
     #{<<"@type">> => [Object]};
 triple_to_map(#triple{subject = Id, predicate = Predicate, object = #rdf_value{value = Object, language = undefined, type = undefined}}, #rdf_resource{id = Id}) ->
@@ -358,7 +360,9 @@ merge_triples(#rdf_resource{} = RdfResource, Subject) ->
 
 %% @doc Merge a key/value map into an accumulator map, combining multiple
 %% values for the same key.
--spec merge_values(map(), map()) -> map().
+-spec merge_values(undefined | map(), map()) -> map().
+merge_values(undefined, Acc) ->
+    Acc;
 merge_values(KeyValue, Acc) ->
     %% Read current key from KeyValue pair
     Key = hd(maps:keys(KeyValue)),

--- a/modules/mod_ginger_rdf/support/ginger_turtle.erl
+++ b/modules/mod_ginger_rdf/support/ginger_turtle.erl
@@ -19,6 +19,8 @@ triple_to_turtle(#triple{subject = S, predicate = P, object = #rdf_resource{} = 
         end,
     Ts = [triple_to_turtle(T#triple{subject = O}) || T <- Rsc#rdf_resource.triples],
     [to_line(subject(S), predicate(P), O), Ts];
+triple_to_turtle(#triple{object = undefined}) ->
+    [];
 triple_to_turtle(#triple{subject = undefined, predicate = P, object = O}) ->
     to_line(<<"[]">>, predicate(P), object(O));
 triple_to_turtle(#triple{subject = S, predicate = P, object = O}) ->

--- a/modules/mod_ginger_rdf/support/rdf_property.erl
+++ b/modules/mod_ginger_rdf/support/rdf_property.erl
@@ -6,6 +6,7 @@
     dcterms/1,
     foaf/1,
     geo/1,
+    hydra/1,
     rdf/1,
     rdfs/1,
     schema/1,
@@ -30,6 +31,10 @@ foaf(Property) ->
 -spec geo(binary()) -> ginger_uri:uri().
 geo(Property) ->
     property(?NS_GEO, Property).
+
+-spec hydra(binary()) -> ginger_uri:uri().
+hydra(Property) ->
+    property(?NS_HYDRA, Property).
 
 -spec rdf(binary()) -> ginger_uri:uri().
 rdf(Property) ->


### PR DESCRIPTION
* Add a controller at `/hydra/123` that serializes Zotonic queries
  as Hydra collections, either in JSON-LD or Turtle.
* Hydra gives machine-readable pagination over large collections.
  See﻿ https://www.hydra-cg.com/spec/latest/core/.
* Filter out empty triple objects in both JSON-LD and Turtle serializations.
  This makes it easy to dump some triples that may not have a value,
  such as previous or next page in our case. 
* The `/hydra` endpoint can be used as the RDF distribution of datasets,
  which are a subcategory of `query`. 
* Add documentation.