### PR TITLE
[rdf] Support multiple ontologies in controllers

### DIFF
--- a/modules/mod_ginger_rdf/controllers/controller_hydra.erl
+++ b/modules/mod_ginger_rdf/controllers/controller_hydra.erl
@@ -17,7 +17,7 @@
 -include_lib("../include/rdf.hrl").
 
 -record(state, {
-    ontology :: atom(),
+    ontologies :: atom(),
     limit :: non_neg_integer(),
     context :: z:context()
 }).
@@ -30,7 +30,7 @@ service_available(ReqData, Args) ->
     Context2 = cors_headers:allow_all_cors(Context),
     State = #state{
         context = Context2,
-        ontology = proplists:get_value(ontology, Args),
+        ontologies = proplists:get_value(ontologies, Args),
         limit = proplists:get_value(limit, Args, 100)
     },
     case wrq:method(ReqData) of
@@ -77,7 +77,7 @@ to_hydra(ReqData, State) ->
         next = Next,
         prev = Previous
     } = z_search:search_pager({query, [{query_id, QueryId}]}, Page, Limit, Context),
-    RdfResults = [m_rdf_export:to_rdf(Id, [State#state.ontology], Context) || Id <- Result],
+    RdfResults = [m_rdf_export:to_rdf(Id, State#state.ontologies, Context) || Id <- Result],
 
     HydraCollectionUrl = hydra_url(QueryId, page(RequestArgs, undefined), Context), %% The Hydra collection.
     HydraViewUrl = hydra_url(QueryId, page(RequestArgs, Page), Context), %% The paged view on the Hydra collection.

--- a/modules/mod_ginger_rdf/controllers/controller_hydra.erl
+++ b/modules/mod_ginger_rdf/controllers/controller_hydra.erl
@@ -17,7 +17,7 @@
 -include_lib("../include/rdf.hrl").
 
 -record(state, {
-    ontologies :: atom(),
+    ontologies :: [atom()],
     limit :: non_neg_integer(),
     context :: z:context()
 }).

--- a/modules/mod_ginger_rdf/controllers/controller_rdf.erl
+++ b/modules/mod_ginger_rdf/controllers/controller_rdf.erl
@@ -16,7 +16,7 @@
 
 -record(state, {
     serialization :: atom(),
-    ontologies :: atom(),
+    ontologies :: [atom()],
     context :: z:context()
 }).
 

--- a/modules/mod_ginger_rdf/controllers/controller_rdf.erl
+++ b/modules/mod_ginger_rdf/controllers/controller_rdf.erl
@@ -16,7 +16,7 @@
 
 -record(state, {
     serialization :: atom(),
-    ontology :: atom(),
+    ontologies :: atom(),
     context :: z:context()
 }).
 
@@ -29,7 +29,8 @@ service_available(ReqData, Args) ->
     State = #state{
         context = Context2,
         serialization = proplists:get_value(serialization, Args),
-        ontology = proplists:get_value(ontology, Args)
+        %% Fall back to {ontology, a_single_ontology} for BC.
+        ontologies = proplists:get_value(ontologies, Args, [proplists:get_value(ontology, Args)])
     },
     case wrq:method(ReqData) of
         'OPTIONS' ->
@@ -58,7 +59,7 @@ id(Context) ->
 
 rdf(ReqData, State) ->
     Context1 = z_context:set_reqdata(ReqData, State#state.context),
-    RdfResource = m_rdf_export:to_rdf(id(Context1), [State#state.ontology], Context1),
+    RdfResource = m_rdf_export:to_rdf(id(Context1), State#state.ontologies, Context1),
     SerializedRdf = serialize(RdfResource, State#state.serialization),
     ?WM_REPLY(SerializedRdf, Context1).
 

--- a/modules/mod_ginger_rdf/dispatch/dispatch
+++ b/modules/mod_ginger_rdf/dispatch/dispatch
@@ -1,5 +1,5 @@
 [
-    {rsc_json_ld, ["rdf", id], controller_rdf, [{serialization, json_ld}, {ontology, schema_org}]},
-    {rsc_turtle, ["turtle", id], controller_rdf, [{serialization, turtle}, {ontology, schema_org}]},
-    {hydra, ["hydra", id], controller_hydra, [{ontology, schema_org}]}
+    {rsc_json_ld, ["rdf", id], controller_rdf, [{serialization, json_ld}, {ontologies, [schema_org]}]},
+    {rsc_turtle, ["turtle", id], controller_rdf, [{serialization, turtle}, {ontologies, [schema_org]}]},
+    {hydra, ["hydra", id], controller_hydra, [{ontologies, [schema_org]}]}
 ].


### PR DESCRIPTION
* Keep `ontology` for BC with existing dispatch rules in sites.
