### PR TITLE
[base] Include unique name in /data/resources output

### DIFF
--- a/modules/mod_ginger_base/models/m_ginger_rest.erl
+++ b/modules/mod_ginger_base/models/m_ginger_rest.erl
@@ -19,6 +19,7 @@
 -spec rsc(m_rsc:resource(), z:context()) -> resource_properties() | undefined.
 rsc(Id, Context) when is_integer(Id) ->
     Rsc = #{ <<"id">> => Id
+           , <<"name">> => m_rsc:p(Id, name, null, Context)
            , <<"title">> => translations(Id, title, Context)
            , <<"subtitle">> => translations(Id, subtitle, Context)
            , <<"body">> => translations(Id, body, Context)


### PR DESCRIPTION
As the resource unique name is a core concept and tool within Zotonic/Ginger domain modelling it is quite surprising that it wasn't included in the resource representations yet. Did I miss anything that opposes inclusion of the resource unique name?