### PR TITLE
Allow for the predicate to be specified in hassubjects and hasobjects queries

### DIFF
--- a/modules/mod_ginger_base/support/ginger_search.erl
+++ b/modules/mod_ginger_base/support/ginger_search.erl
@@ -20,6 +20,8 @@
     custompivots,
     filters,
     has_geo,
+    hassubjects,
+    hasobjects,
     is_findable,
     keyword,
     ongoing_on_date,
@@ -157,7 +159,7 @@ parse_argument({Key, <<"undefined">>}) ->
 parse_argument({hassubjects, Subjects}) ->
     lists:map(
         fun(Subject) ->
-            {hassubject, Subject}
+            {hassubject, parse_predicate(Subject)}
         end,
         Subjects
     );
@@ -165,7 +167,7 @@ parse_argument({hassubjects, Subjects}) ->
 parse_argument({hasobjects, Objects}) ->
     lists:map(
         fun(Object) ->
-            {hasobject, Object}
+            {hasobject, parse_predicate(Object)}
         end,
         Objects
     );
@@ -299,6 +301,12 @@ parse_argument({boost_featured, true}) ->
 
 parse_argument(Arg) ->
     [Arg].
+
+parse_predicate(P) ->
+    case P of
+        [Node, PredName] -> [Node, z_convert:to_atom(PredName)];
+        _ -> P
+    end.
 
 date_facet(Property) ->
     %% A facet on a date property is a min/max range.

--- a/modules/mod_ginger_base/support/ginger_search.erl
+++ b/modules/mod_ginger_base/support/ginger_search.erl
@@ -304,7 +304,7 @@ parse_argument(Arg) ->
 
 parse_predicate(P) ->
     case P of
-        [Node, PredName] -> [Node, z_convert:to_atom(PredName)];
+        [Node, PredName] -> [Node, erlang:binary_to_existing_atom(PredName)];
         _ -> P
     end.
 


### PR DESCRIPTION
This allows for querying resources having subjects or objects with a specific predicate (e.g. `haspart`).