### PR TITLE
Fix search suggestions not being clickable

### DIFF
--- a/modules/mod_ginger_base/templates/search-suggestions/toggle-search.tpl
+++ b/modules/mod_ginger_base/templates/search-suggestions/toggle-search.tpl
@@ -1,5 +1,5 @@
 {% with class|default:"search-suggestions__toggle-search" as class %}
-	<a href="#" class="{{ class }} {{ extraClasses }}" id="toggle-search">
+	<a tabindex="0" href="#" class="{{ class }} {{ extraClasses }}" id="toggle-search">
 	    <i class="icon--search"></i> <span>{_ Search _} </span>
 	</a>
 {% endwith %}


### PR DESCRIPTION
This fixes Mantis 30804 and adds proper tabbing behaviour to the standard Ginger search bar:
1. Enter on search button opens the search bar
2. Pressing tab in the search bar closes the search bar (navigate search suggestions with arrow keys)
3. Search input cannot be focused when it's hidden
4. Ensure search toggle is focusable in Safari (Fix from Rietveld for Mantis 30717)