### PR TITLE
Elasticsearch2 Adlib support

### DIFF
--- a/modules/mod_ginger_adlib_elasticsearch2/mod_ginger_adlib_elasticsearch2.erl
+++ b/modules/mod_ginger_adlib_elasticsearch2/mod_ginger_adlib_elasticsearch2.erl
@@ -39,8 +39,9 @@ observe_adlib_update(#adlib_update{date = _Date, database = Database, record = #
     MappedRecord1 = MappedRecord#{
         <<"es_type">> => Database
     },
-    case elasticsearch2:put_doc(index(Context), Priref, MappedRecord1, Context) of
-        {ok, _} ->
+    DocId = mod_elasticsearch2:typed_id(Priref, Database),
+    case mod_elasticsearch2:put_doc(index(Context), DocId, MappedRecord1, Context) of
+        ok ->
             ok;
         {error, Message} ->
             lager:error("Record with priref ~s from database ~p could not be saved to Elasticsearch: ~p", [Priref, Database, Message])

--- a/modules/mod_ginger_collection/filters/filter_collection_object_url.erl
+++ b/modules/mod_ginger_collection/filters/filter_collection_object_url.erl
@@ -1,0 +1,59 @@
+-module(filter_collection_object_url).
+
+-export([
+    collection_object_url/2
+]).
+
+collection_object_url(#{ <<"_id">> := DocId, <<"_type">> := <<"resource">> }, Context) ->
+    url(<<"resource">>, DocId, Context);
+collection_object_url(#{ <<"_id">> := DocId, <<"_source">> := #{ <<"es_type">> := <<"resource">> } }, Context) ->
+    url(<<"resource">>, DocId, Context);
+collection_object_url(#{ <<"_source">> := #{ <<"es_type">> := Type, <<"@id">> := Id } }, Context) ->
+    % Elastic Search 7.x and later  (mod_elasticsearch2)
+    url(Type, Id, Context);
+collection_object_url(#{ <<"_source">> := #{ <<"es_type">> := Type, <<"priref">> := Id } }, Context) ->
+    % Elastic Search 7.x and later  (mod_elasticsearch2)
+    url(Type, Id, Context);
+collection_object_url(#{ <<"_id">> := DocId, <<"_source">> := #{ <<"es_type">> := Type } }, Context) ->
+    % Elastic Search 7.x and later  (mod_elasticsearch2)
+    {Id, _} = mod_elasticsearch2:typed_id_split(DocId),
+    url(Type, Id, Context);
+collection_object_url(#{ <<"_type">> := Type, <<"_source">> := #{ <<"@id">> := Id } }, Context) ->
+    % Elastic Search 5.x (mod_elasticsearch)
+    url(Type, Id, Context);
+collection_object_url(#{ <<"_type">> := Type, <<"_source">> := #{ <<"priref">> := Id } }, Context) ->
+    % Elastic Search 5.x (mod_elasticsearch)
+    url(Type, Id, Context);
+collection_object_url(#{ <<"_id">> := DocId, <<"_type">> := Type }, Context) ->
+    % Not all sites have elasticsearch2
+    Id = case m_ginger_collection:is_elastic2(Context) of
+        true ->
+            {SplitId, _} = mod_elasticsearch2:typed_id_split(DocId),
+            SplitId;
+        false ->
+            DocId
+    end,
+    url(Type, Id, Context);
+collection_object_url(#{ <<"_id">> := DocId }, Context) ->
+    % In future we might not have the _type added by mod_elasticsearch2
+    {Id, Type} = mod_elasticsearch2:typed_id_split(DocId),
+    url(Type, Id, Context);
+collection_object_url(_Doc, _Context) ->
+    undefined.
+
+
+url(Type, Id, Context)
+    when Type =:= <<"resource">>;
+         Type =:= <<>>;
+         Type =:= undefined ->
+    case m_rsc:rid(Id, Context) of
+        undefined ->
+            undefined;
+        RId ->
+            m_rsc:page_url(RId, Context)
+    end;
+url(Type, Id, Context) ->
+    z_dispatcher:url_for(
+        collection_object,
+        [ {database, Type}, {object_id, Id}],
+        Context).

--- a/modules/mod_ginger_collection/models/m_collection_object.erl
+++ b/modules/mod_ginger_collection/models/m_collection_object.erl
@@ -57,7 +57,8 @@ get(Type, Id, Context) ->
     Index = m_ginger_collection:collection_index(Context),
     case m_ginger_collection:is_elastic2(Context) of
         true ->
-            elasticsearch2:get_doc(Index, Id, Context);
+            DocId = mod_elasticsearch2:typed_id(Id, Type),
+            elasticsearch2:get_doc(Index, DocId, Context);
         false ->
             case erlastic_search:get_doc(
                 Index,
@@ -78,7 +79,8 @@ store(Type, Id, Document, Context) ->
             Document1 = Document#{
                 <<"es_type">> => Type
             },
-            elasticsearch2:put_doc(Index, Id, Document1, Context);
+            DocId = mod_elasticsearch2:typed_id(Id, Type),
+            elasticsearch2:put_doc(Index, DocId, Document1, Context);
         false ->
             elasticsearch:put_doc(Index, Type, Id, Document, Context)
     end.

--- a/modules/mod_ginger_collection/templates/collection/list/list-item-carousel.tpl
+++ b/modules/mod_ginger_collection/templates/collection/list/list-item-carousel.tpl
@@ -1,6 +1,6 @@
 {% with item._source as record %}
     <li class="list__item--carousel {{ extraClasses }}">
-        <a href="{% url collection_object database=item._type object_id=record.priref %}">
+        <a href="{{ item|collection_object_url }}">
             {% block item_image %}
                 {% include "collection/depiction.tpl" record=record width=400 height=400 template="list/list-item-image.tpl" %}
             {% endblock %}

--- a/modules/mod_ginger_collection/templates/collection/list/list-item.tpl
+++ b/modules/mod_ginger_collection/templates/collection/list/list-item.tpl
@@ -1,6 +1,6 @@
 {% with item._source as record %}
     <li class="list__item--beeldenzoeker {{ extraClasses }}">
-        <a href="{% block link %}{% url collection_object database=item._type object_id=record.priref %}{% if query_id %}?query_id={{ query_id }}&total={{ total_results }}&current={{ current }}{% endif %}{% endblock %}"{% if link_target %} target="{{ link_target }}"{% endif %}>
+        <a href="{% block link %}{{ item|collection_object_url }}{% if query_id %}?query_id={{ query_id }}&total={{ total_results }}&current={{ current }}{% endif %}{% endblock %}"{% if link_target %} target="{{ link_target }}"{% endif %}>
             {% block item_image %}
                 {% include "collection/depiction.tpl" record=record width=400 height=400 template="list/list-item-image.tpl" %}
             {% endblock %}

--- a/modules/mod_ginger_collection/templates/collection/prevnext.tpl
+++ b/modules/mod_ginger_collection/templates/collection/prevnext.tpl
@@ -5,13 +5,13 @@
     {% with prevnext|last as next %}
         <div class="collection-nav">
         {% if prev|is_defined %}
-            <a class="collection-nav__btn -prev" href="{% url collection_object database=prev._type object_id=prev._source.priref %}?query_id={{ q.query_id|escape }}&total={{ q.total|escape }}&current={{ q.current|escape|to_integer - 1 }}"><i class="icon--arrow-left"></i> <span>{_ Previous _}</span></a>
+            <a class="collection-nav__btn -prev" href="{{ prev|collection_object_url }}?query_id={{ q.query_id|escape }}&total={{ q.total|escape }}&current={{ q.current|escape|to_integer - 1 }}"><i class="icon--arrow-left"></i> <span>{_ Previous _}</span></a>
         {% else %}
             <div class="collection-nav__btn -disabled"></div>
         {% endif %}
         <a href="{{ m.rsc[q.query_id].page_url }}" class="collection-nav__title">{{ m.rsc[q.query_id].title }} <span>{{ q.current|escape }} / {{ q.total|escape }}</span></a>
         {% if next|is_defined %}
-            <a class="collection-nav__btn -next" href="{% url collection_object database=next._type object_id=next._source.priref %}?query_id={{ q.query_id|escape }}&total={{ q.total|escape }}&current={{ q.current|escape|to_integer + 1 }}"><span>{_ Next _}</span> <i class="icon--arrow-right"></i></a>
+            <a class="collection-nav__btn -next" href="{{ next|collection_object_url }}?query_id={{ q.query_id|escape }}&total={{ q.total|escape }}&current={{ q.current|escape|to_integer + 1 }}"><span>{_ Next _}</span> <i class="icon--arrow-right"></i></a>
         {% else %}
             <div class="collection-nav__btn -disabled"></div>
         {% endif %}

--- a/modules/mod_ginger_collection/templates/search-suggestions/search-suggestions.tpl
+++ b/modules/mod_ginger_collection/templates/search-suggestions/search-suggestions.tpl
@@ -4,7 +4,7 @@
         {% for result in items|slice:6 %}
             {% with result._source as item %}
                 <li>
-                    <a href="{% if item.priref %}{% url collection_object database=result._type object_id=item.priref %}{% else %}{{ m.rsc[item.id].page_url }}{% endif %}">
+                    <a href="{{ result|collection_object_url }}">
                         {% include "collection/depiction.tpl" record=item width=100 height=100 template="search-suggestions/search-suggestions-image.tpl" %}
                         <p class="search-suggestions__suggestions__list__title">{{ item['dcterms:title']|default:m.rsc[item.id].title }} </p>
                     </a>


### PR DESCRIPTION
Add support for mod_elasticsearch2 to the Adlib/collection modules.

In ES7+ the _type is removed, as we used it for the Adlib database reference when storing documents we now have to combine the type and priref of a record to make an unique document `_id`  (as multiple databases can have the same priref).

The filter `collection_object_url` can now be used to make `collection_object` urls, this instead of manually combining the type and id in the template (or Erlang code).

See also: https://github.com/driebit/mod_elasticsearch2/pull/5