### PR TITLE
Fix an issue with dynamic elastic-ids

### DIFF
--- a/modules/mod_ginger_collection/models/m_collection_object.erl
+++ b/modules/mod_ginger_collection/models/m_collection_object.erl
@@ -26,12 +26,20 @@ m_find_value(uri, #m{value = undefined}, Context) ->
         ],
         Context
     );
-m_find_value(Type, #m{value = undefined} = M, _Context) ->
-    M#m{value = Type};
+m_find_value(Property, #m{value = undefined} = M, Context) ->
+    Property2 = z_convert:to_binary(Property),
+    case mod_elasticsearch2:typed_id_split(Property2) of
+        {Type, <<>>} -> M#m{value = Type};
+        {_Id, _Type} -> get(Property2, Context)
+    end;
 m_find_value(Property, #m{value = #{<<"_index">> := _Index} = Object}, _Context) ->
     maps:get(z_convert:to_binary(Property), Object);
 m_find_value(ObjectId, #m{value = Type}, Context) ->
-    get(Type, ObjectId, Context).
+    ObjectId2 = z_convert:to_binary(ObjectId),
+    case mod_elasticsearch2:typed_id_split(ObjectId2) of
+        {_Type, <<>>} -> get(Type, ObjectId2, Context);
+        {_Id, _Type} -> get(ObjectId2, Context)
+    end.
 
 m_to_list(_, _Context) ->
     [].


### PR DESCRIPTION
Looking up an object with `m.collection_object["Object"][id]` was broken when id was an elastic2 id (with `::Type` appended). This commit fixes this and allows lookup with `m.collection_object[id]` as well.