### PR TITLE
mod_ginger_collection: set enoent doc warning to 'debug' level

### DIFF
--- a/modules/mod_ginger_collection/models/m_collection_object.erl
+++ b/modules/mod_ginger_collection/models/m_collection_object.erl
@@ -75,7 +75,7 @@ get(Type, Id, Context) ->
                 {ok, Doc} ->
                     Doc;
                 {error, enoent} ->
-                    lager:info("m_collection_object: document not found '~s' index '~s'",
+                    lager:debug("m_collection_object: document not found '~s' index '~s'",
                                [ DocId, Index ]),
                     undefined;
                 {error, _} ->


### PR DESCRIPTION
The fetch document routine is also frequently used to check _if_ a document is present.
That check now generates a log entry, which is somewhat unexpected.