### PR TITLE
mod_ginger_collection: fix filter on dates before the year 1000

### DIFF
--- a/modules/mod_ginger_collection/support/collection_query.erl
+++ b/modules/mod_ginger_collection/support/collection_query.erl
@@ -168,10 +168,12 @@ map_related_to_property(#triple{}, QueryArgs) ->
 
 date_filter(_Key, _Operator, <<>>, _IncludeMissing) ->
     [];
-date_filter(Key, Operator, Value, IncludeMissing) when Operator =:= <<"gte">>; Operator =:= <<"gt">>;
+date_filter(Key, Operator, Value, IncludeMissing) when
+    Operator =:= <<"gte">>; Operator =:= <<"gt">>;
     Operator =:= <<"lte">>; Operator =:= <<"lt">>
 ->
-    DateFilter = [Key, Operator, Value, [{<<"format">>, <<"yyyy">>}]],
+    % Use "year", as "yyyy" is strict and gives an exception on years < 1000.
+    DateFilter = [Key, Operator, Value, [{<<"format">>, <<"year">>}]],
     OrFilters = case IncludeMissing of
         true ->
             [DateFilter, [Key, missing]];


### PR DESCRIPTION
The 'yyyy' format is strict and only accepts a date >= 1000.
The 'year' format is less strict and accepts any integer value.