### PR TITLE
[mod_ginger_base] Force httpss (note the extra s) links to https

### DIFF
--- a/modules/mod_ginger_base/support/ginger_uri.erl
+++ b/modules/mod_ginger_base/support/ginger_uri.erl
@@ -24,4 +24,6 @@ uri(<<"https://", _/binary>> = Uri) ->
 https(<<"http://", Uri/binary>>) ->
     <<"https://", Uri/binary>>;
 https(<<"https://", _/binary>> = Uri) ->
-    Uri.
+    Uri;
+https(<<"httpss://", Uri/binary>>) ->
+    <<"https://", Uri/binary>>.


### PR DESCRIPTION
Expected to fix site breakage, where this typo appeared in an rdf resource.