### PR TITLE
Fix an issue with ginger rest and translatable page paths

### DIFF
--- a/modules/mod_ginger_base/models/m_ginger_rest.erl
+++ b/modules/mod_ginger_base/models/m_ginger_rest.erl
@@ -24,7 +24,7 @@ rsc(Id, Context) when is_integer(Id) ->
            , <<"subtitle">> => translations(Id, subtitle, Context)
            , <<"body">> => translations(Id, body, Context)
            , <<"summary">> => translations(Id, summary, Context)
-           , <<"path">> => m_rsc:p(Id, page_path, m_rsc:page_url(Id, Context), Context)
+           , <<"path">> => m_rsc:p(Id, page_url, Context)
            , <<"publication_date">> => m_rsc:p(Id, publication_start, null, Context)
            , <<"categories">> => proplists:get_value(is_a, m_rsc:p(Id, category, Context))
            , <<"properties">> => custom_props(Id, Context)


### PR DESCRIPTION
In Zotonic 0.89 the page_path is translatable.
That gives a problem with the (rather unusual) construction in ginger_rest to fetch the url of a page.

This fixes that problem by requesting the page_url from the rsc model.