### PR TITLE
Fix controller_rest's issue with page paths

### DIFF
--- a/modules/mod_ginger_base/controllers/controller_rest_resources.erl
+++ b/modules/mod_ginger_base/controllers/controller_rest_resources.erl
@@ -253,9 +253,15 @@ path_to_id("/", Context) ->
 path_to_id(Path, Context) ->
     case string:tokens(Path, "/") of
         ["page", Id | _] ->
-            {ok, erlang:list_to_integer(Id)};
+            case m_rsc:rid(Id, Context) of
+                undefined -> {error, enoent};
+                RscId -> {ok, RscId}
+            end;
         [_Language, "page", Id | _] ->
-            {ok, erlang:list_to_integer(Id)};
+            case m_rsc:rid(Id, Context) of
+                undefined -> {error, enoent};
+                RscId -> {ok, RscId}
+            end;
         _ ->
             case m_rsc:page_path_to_id(Path, Context) of
                 {redirect, Id} ->


### PR DESCRIPTION
The current `controller_rest_resources:path_to_id` expects the page path to contain an integer and fails catastrophically otherwise.

I triggered this accidentally while testing for another issue by using a path with text (e.g. `/page/not_existing`) which `controller_page` can handle just fine, but `controller_rest_resources` crashes on.

This fixes the function to accept paths that might contain a resource’s unique name (as `controller_page` does) and by not crashing on incorrect inputs (it returns an error tuple instead).



